### PR TITLE
Udelej, aby pri novem deploy nactena stranka automaticky zjistila, ze je novy deploy, a zobrazila zpravu s tlacitkem "Re

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,6 +1,18 @@
 /** @type {import('next').NextConfig} */
+
+// Generate a unique build ID at build time — changes automatically on every
+// `next build` so clients can detect when a new deploy is available.
+const buildId = Date.now().toString();
+
 const nextConfig = {
   reactStrictMode: false, // disabled to avoid double-mount issues with WebAudio
+  generateBuildId: async () => buildId,
+  env: {
+    // Exposed to server-side code only (not inlined into client bundles).
+    // The /app-version route handler reads this and returns it to the client
+    // for polling-based new-deploy detection.
+    NEXT_BUILD_ID: buildId,
+  },
   async rewrites() {
     return [
       {

--- a/apps/web/src/__tests__/VersionBanner.test.tsx
+++ b/apps/web/src/__tests__/VersionBanner.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import VersionBanner from '../components/VersionBanner';
+import * as useVersionCheckModule from '../hooks/useVersionCheck';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockVersionCheck(status: useVersionCheckModule.VersionStatus) {
+  const dismiss = vi.fn();
+  vi.spyOn(useVersionCheckModule, 'useVersionCheck').mockReturnValue({ status, dismiss });
+  return { dismiss };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('VersionBanner', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when status is null', () => {
+    mockVersionCheck(null);
+    const { container } = render(<VersionBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the welcome banner when status is "welcome"', () => {
+    mockVersionCheck('welcome');
+    render(<VersionBanner />);
+    expect(screen.getByText(/vítejte v nové verzi/i)).toBeDefined();
+  });
+
+  it('renders the update-available banner when status is "update-available"', () => {
+    mockVersionCheck('update-available');
+    render(<VersionBanner />);
+    expect(screen.getByText(/dostupná nová verze/i)).toBeDefined();
+  });
+
+  it('shows an "Obnovit" button in update-available state', () => {
+    mockVersionCheck('update-available');
+    render(<VersionBanner />);
+    expect(screen.getByRole('button', { name: /obnovit/i })).toBeDefined();
+  });
+
+  it('"Obnovit" button calls window.location.reload()', () => {
+    mockVersionCheck('update-available');
+    const reloadMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload: reloadMock },
+      writable: true,
+    });
+
+    render(<VersionBanner />);
+    fireEvent.click(screen.getByRole('button', { name: /obnovit/i }));
+    expect(reloadMock).toHaveBeenCalledOnce();
+  });
+
+  it('dismiss button calls dismiss() in update-available state', () => {
+    const { dismiss } = mockVersionCheck('update-available');
+    render(<VersionBanner />);
+    fireEvent.click(screen.getByRole('button', { name: /zavřít/i }));
+    expect(dismiss).toHaveBeenCalledOnce();
+  });
+
+  it('dismiss button calls dismiss() in welcome state', () => {
+    const { dismiss } = mockVersionCheck('welcome');
+    render(<VersionBanner />);
+    fireEvent.click(screen.getByRole('button', { name: /zavřít/i }));
+    expect(dismiss).toHaveBeenCalledOnce();
+  });
+
+  it('auto-dismisses the welcome banner after 6 s', () => {
+    const { dismiss } = mockVersionCheck('welcome');
+    render(<VersionBanner />);
+
+    act(() => {
+      vi.advanceTimersByTime(6_001);
+    });
+
+    expect(dismiss).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT auto-dismiss the update-available banner', () => {
+    const { dismiss } = mockVersionCheck('update-available');
+    render(<VersionBanner />);
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(dismiss).not.toHaveBeenCalled();
+  });
+
+  it('banner has role="status" for accessibility', () => {
+    mockVersionCheck('welcome');
+    render(<VersionBanner />);
+    expect(screen.getByRole('status')).toBeDefined();
+  });
+});

--- a/apps/web/src/__tests__/useVersionCheck.test.tsx
+++ b/apps/web/src/__tests__/useVersionCheck.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useVersionCheck } from '../hooks/useVersionCheck';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const BUILD_ID_V1 = 'build-v1';
+const BUILD_ID_V2 = 'build-v2';
+const VERSION_KEY = 'app_last_seen_version';
+
+function setNextDataBuildId(buildId: string) {
+  (window as unknown as Record<string, unknown>).__NEXT_DATA__ = { buildId };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useVersionCheck', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    setNextDataBuildId(BUILD_ID_V1);
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ buildId: BUILD_ID_V1 }), { status: 200 }),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    delete (window as unknown as Record<string, unknown>).__NEXT_DATA__;
+  });
+
+  it('returns null status on very first visit (no prior localStorage)', () => {
+    const { result } = renderHook(() => useVersionCheck());
+    expect(result.current.status).toBeNull();
+  });
+
+  it('stores the current build ID in localStorage on first visit', () => {
+    renderHook(() => useVersionCheck());
+    expect(localStorage.getItem(VERSION_KEY)).toBe(BUILD_ID_V1);
+  });
+
+  it('returns null status when user revisits the same version', () => {
+    localStorage.setItem(VERSION_KEY, BUILD_ID_V1);
+    const { result } = renderHook(() => useVersionCheck());
+    expect(result.current.status).toBeNull();
+  });
+
+  it('returns "welcome" status when user sees a new build for the first time', () => {
+    // User previously saw V1, now loading V2
+    localStorage.setItem(VERSION_KEY, BUILD_ID_V1);
+    setNextDataBuildId(BUILD_ID_V2);
+
+    const { result } = renderHook(() => useVersionCheck());
+    expect(result.current.status).toBe('welcome');
+  });
+
+  it('updates localStorage to the new build ID when showing welcome', () => {
+    localStorage.setItem(VERSION_KEY, BUILD_ID_V1);
+    setNextDataBuildId(BUILD_ID_V2);
+
+    renderHook(() => useVersionCheck());
+    expect(localStorage.getItem(VERSION_KEY)).toBe(BUILD_ID_V2);
+  });
+
+  it('dismiss() clears the status', () => {
+    localStorage.setItem(VERSION_KEY, BUILD_ID_V1);
+    setNextDataBuildId(BUILD_ID_V2);
+
+    const { result } = renderHook(() => useVersionCheck());
+    expect(result.current.status).toBe('welcome');
+
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.status).toBeNull();
+  });
+
+  it('returns "update-available" when server reports a newer build', async () => {
+    // Client is on V1, server returns V2
+    setNextDataBuildId(BUILD_ID_V1);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ buildId: BUILD_ID_V2 }), { status: 200 }),
+    );
+
+    const { result } = renderHook(() => useVersionCheck());
+
+    // Advance past the initial poll delay (10 s)
+    await act(async () => {
+      vi.advanceTimersByTime(10_001);
+    });
+
+    expect(result.current.status).toBe('update-available');
+  });
+
+  it('does not change status when server returns the same build ID', async () => {
+    const { result } = renderHook(() => useVersionCheck());
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_001);
+    });
+
+    expect(result.current.status).toBeNull();
+  });
+
+  it('does not throw when fetch fails (network error)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useVersionCheck());
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_001);
+    });
+
+    expect(result.current.status).toBeNull();
+  });
+
+  it('does not change status when server returns non-ok response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Internal Server Error', { status: 500 }),
+    );
+
+    const { result } = renderHook(() => useVersionCheck());
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_001);
+    });
+
+    expect(result.current.status).toBeNull();
+  });
+
+  it('polls again after the full interval (60 s)', async () => {
+    const mockFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ buildId: BUILD_ID_V1 }), { status: 200 }),
+    );
+
+    renderHook(() => useVersionCheck());
+
+    // Initial poll at 10 s
+    await act(async () => {
+      vi.advanceTimersByTime(10_001);
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Second poll at 10 + 60 s
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans up timers on unmount', async () => {
+    const mockFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ buildId: BUILD_ID_V1 }), { status: 200 }),
+    );
+
+    const { unmount } = renderHook(() => useVersionCheck());
+    unmount();
+
+    // Advancing time should NOT trigger any fetch after unmount
+    await act(async () => {
+      vi.advanceTimersByTime(70_001);
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to "dev" build ID when __NEXT_DATA__ is absent', () => {
+    delete (window as unknown as Record<string, unknown>).__NEXT_DATA__;
+    localStorage.setItem(VERSION_KEY, 'some-old-value');
+
+    const { result } = renderHook(() => useVersionCheck());
+    // "dev" !== "some-old-value" → welcome should show
+    expect(result.current.status).toBe('welcome');
+    expect(localStorage.getItem(VERSION_KEY)).toBe('dev');
+  });
+});

--- a/apps/web/src/app/app-version/route.ts
+++ b/apps/web/src/app/app-version/route.ts
@@ -1,0 +1,8 @@
+// This endpoint is polled by the client to detect when a new deploy is live.
+// It returns the build ID that was baked in at `next build` time.
+// Note: must NOT be under /api/* — that prefix is rewritten to the backend API.
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return Response.json({ buildId: process.env.NEXT_BUILD_ID ?? 'dev' });
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import FeedbackButton from '@/components/FeedbackButton';
+import VersionBanner from '@/components/VersionBanner';
 
 export const metadata: Metadata = {
   title: 'Video Editor',
@@ -12,6 +13,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body style={{ height: '100vh', overflow: 'hidden' }}>
         {children}
+        <VersionBanner />
         <FeedbackButton />
       </body>
     </html>

--- a/apps/web/src/components/VersionBanner.tsx
+++ b/apps/web/src/components/VersionBanner.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useVersionCheck } from '@/hooks/useVersionCheck';
+
+const AUTO_DISMISS_MS = 6_000;
+
+const BANNER_BASE_STYLE: React.CSSProperties = {
+  position: 'fixed',
+  top: '16px',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  zIndex: 10000,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '10px',
+  padding: '10px 16px',
+  borderRadius: '12px',
+  background: 'rgba(14, 26, 46, 0.96)',
+  backdropFilter: 'blur(24px) saturate(1.5)',
+  WebkitBackdropFilter: 'blur(24px) saturate(1.5)',
+  border: '1px solid rgba(0,212,160,0.30)',
+  boxShadow: '0 0 32px rgba(0,212,160,0.18), 0 8px 32px rgba(0,0,0,0.50)',
+  animation: 'versionBannerIn 0.25s cubic-bezier(0.4,0,0.2,1) forwards',
+  whiteSpace: 'nowrap',
+};
+
+const DISMISS_BTN_STYLE: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  color: 'rgba(255,255,255,0.40)',
+  cursor: 'pointer',
+  fontSize: '18px',
+  lineHeight: 1,
+  padding: '2px 4px',
+  flexShrink: 0,
+};
+
+const KEYFRAMES = `
+  @keyframes versionBannerIn {
+    from { opacity: 0; transform: translateX(-50%) translateY(-10px); }
+    to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+  }
+`;
+
+// ─── Icons ────────────────────────────────────────────────────────────────────
+
+function IconClock() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+      <circle cx="8" cy="8" r="7" stroke="#00d4a0" strokeWidth="1.5" opacity="0.55" />
+      <path d="M8 4.5v3.5l2 2" stroke="#00d4a0" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function IconCheck() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+      <circle cx="8" cy="8" r="7" stroke="#00d4a0" strokeWidth="1.5" opacity="0.55" />
+      <path d="M5 8l2.5 2.5L11 5.5" stroke="#00d4a0" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function VersionBanner() {
+  const { status, dismiss } = useVersionCheck();
+
+  // Auto-dismiss the "welcome" toast after a few seconds.
+  useEffect(() => {
+    if (status !== 'welcome') return;
+    const timer = setTimeout(dismiss, AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [status, dismiss]);
+
+  if (!status) return null;
+
+  if (status === 'update-available') {
+    return (
+      <div role="status" aria-live="polite" style={BANNER_BASE_STYLE}>
+        <style>{KEYFRAMES}</style>
+        <IconClock />
+        <span style={{ color: 'rgba(216,240,234,0.90)', fontSize: '13px', fontWeight: 500 }}>
+          Dostupná nová verze
+        </span>
+        <button
+          onClick={() => window.location.reload()}
+          style={{
+            background: 'linear-gradient(135deg, #00d4a0, #38bdf8)',
+            border: 'none',
+            borderRadius: '7px',
+            padding: '5px 13px',
+            fontSize: '12px',
+            fontWeight: 700,
+            color: '#040a08',
+            cursor: 'pointer',
+            flexShrink: 0,
+          }}
+        >
+          Obnovit
+        </button>
+        <button onClick={dismiss} aria-label="Zavřít" style={DISMISS_BTN_STYLE}>
+          ×
+        </button>
+      </div>
+    );
+  }
+
+  // status === 'welcome'
+  return (
+    <div role="status" aria-live="polite" style={BANNER_BASE_STYLE}>
+      <style>{KEYFRAMES}</style>
+      <IconCheck />
+      <span style={{ color: 'rgba(216,240,234,0.90)', fontSize: '13px', fontWeight: 500 }}>
+        Vítejte v nové verzi!
+      </span>
+      <button onClick={dismiss} aria-label="Zavřít" style={DISMISS_BTN_STYLE}>
+        ×
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useVersionCheck.ts
+++ b/apps/web/src/hooks/useVersionCheck.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+
+const VERSION_KEY = 'app_last_seen_version';
+const POLL_INTERVAL_MS = 60_000; // check every 60 s
+const INITIAL_POLL_DELAY_MS = 10_000; // first check after 10 s
+
+export type VersionStatus = 'welcome' | 'update-available' | null;
+
+/**
+ * Detects two kinds of version changes:
+ *
+ * 1. "welcome"          – The user just loaded a build they haven't seen before
+ *                         (compared against the last version stored in localStorage).
+ *                         Shows a short "Welcome to the new version!" toast.
+ *
+ * 2. "update-available" – A newer build has been deployed while the user is still
+ *                         on the old page (detected by polling /app-version).
+ *                         Shows a persistent banner with a "Refresh" button.
+ *
+ * The build ID comes from Next.js's built-in __NEXT_DATA__.buildId, which is
+ * automatically regenerated on every `next build` (see next.config.mjs).
+ */
+export function useVersionCheck(): { status: VersionStatus; dismiss: () => void } {
+  const [status, setStatus] = useState<VersionStatus>(null);
+
+  const dismiss = useCallback(() => setStatus(null), []);
+
+  useEffect(() => {
+    const currentBuildId: string =
+      (window as unknown as { __NEXT_DATA__?: { buildId?: string } }).__NEXT_DATA__?.buildId ??
+      'dev';
+
+    // ── Welcome detection ─────────────────────────────────────────────────────
+    const lastSeenVersion = localStorage.getItem(VERSION_KEY);
+    if (lastSeenVersion !== null && lastSeenVersion !== currentBuildId) {
+      setStatus('welcome');
+    }
+    localStorage.setItem(VERSION_KEY, currentBuildId);
+
+    // ── New-deploy polling ─────────────────────────────────────────────────────
+    const checkServerVersion = async () => {
+      try {
+        const res = await fetch('/app-version', { cache: 'no-store' });
+        if (!res.ok) return;
+        const data = (await res.json()) as { buildId?: string };
+        if (data.buildId && data.buildId !== currentBuildId) {
+          setStatus('update-available');
+        }
+      } catch {
+        // Silently ignore network errors — the user may be offline.
+      }
+    };
+
+    const initialTimeout = setTimeout(checkServerVersion, INITIAL_POLL_DELAY_MS);
+    const interval = setInterval(checkServerVersion, POLL_INTERVAL_MS);
+
+    return () => {
+      clearTimeout(initialTimeout);
+      clearInterval(interval);
+    };
+  }, []); // runs once on mount
+
+  return { status, dismiss };
+}


### PR DESCRIPTION
## Summary

Done. Here's what was implemented:

**How the build ID works:** `next.config.mjs` now calls `generateBuildId` to produce a `Date.now()` timestamp on every `next build`. This is automatically embedded into `window.__NEXT_DATA__.buildId` by Next.js and also stored in the server-only env var `NEXT_BUILD_ID` — no static file to edit manually.

**Two notifications:**
1. **"Vítejte v nové verzi!"** — shown (and auto-dismissed after 6 s) the first time a user opens a build they haven't seen before, detected by comparing the current build ID against `localStorage`.
2. **"Dostupná nová verze / Obnovit"** — persistent banner shown when the `/app-version` polling endpoint (checked after 10 s and every 60 s thereafter) returns a newer build ID than the one the user's page was loaded with.

## Commits

- feat: auto-detect new deploys and notify users with version banner