### PR TITLE
Pridej prosim ,aby slo nastavit ze ne cele video je vystupni... zkratka chci aby tam kde mame v timeline ty tracks apod.

### DIFF
--- a/apps/api/src/services/ffmpegService.ts
+++ b/apps/api/src/services/ffmpegService.ts
@@ -146,6 +146,8 @@ export interface ExportOptions {
   height?: number;
   crf?: number;
   preset?: string;
+  startTime?: number; // work area start (seconds)
+  endTime?: number;   // work area end (seconds)
 }
 
 export function buildExportCommand(
@@ -401,8 +403,16 @@ export function buildExportCommand(
     args.push('-map', audioOutPad);
   }
 
+  // Output time range: use work area if provided, otherwise full duration
+  const outStart = opts.startTime ?? 0;
+  const outEnd = opts.endTime ?? effectiveDuration;
+  const outDur = Math.max(0.1, outEnd - outStart);
+
+  if (outStart > 0) {
+    args.push('-ss', outStart.toFixed(4));
+  }
   args.push(
-    '-t', effectiveDuration.toFixed(4),   // hard stop — prevents infinite encoding
+    '-t', outDur.toFixed(4),              // hard stop — prevents infinite encoding
     '-c:v', 'libx264',
     '-preset', PRESET,
     '-crf', String(CRF),

--- a/apps/web/src/hooks/useProject.ts
+++ b/apps/web/src/hooks/useProject.ts
@@ -49,7 +49,7 @@ export function useProject() {
     return p;
   }, [setProject]);
 
-  // Compute duration from tracks
+  // Compute duration from tracks; auto-stretch work area if not manual
   const recomputeDuration = useCallback((p: Project): Project => {
     let maxEnd = 0;
     for (const track of p.tracks) {
@@ -57,7 +57,15 @@ export function useProject() {
         if (clip.timelineEnd > maxEnd) maxEnd = clip.timelineEnd;
       }
     }
-    return { ...p, duration: Math.max(maxEnd, 0.1) };
+    const newDuration = Math.max(maxEnd, 0.1);
+    const result: Project = { ...p, duration: newDuration };
+
+    // Auto-stretch work area end to match project duration when not manually set
+    if (!p.workArea || !p.workArea.isManual) {
+      result.workArea = { start: p.workArea?.start ?? 0, end: newDuration, isManual: false };
+    }
+
+    return result;
   }, []);
 
   // Update project (generic)

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -102,7 +102,7 @@ export async function alignLyrics(
 
 export async function exportProject(
   projectId: string,
-  opts?: { width?: number; height?: number; crf?: number; preset?: string }
+  opts?: { width?: number; height?: number; crf?: number; preset?: string; startTime?: number; endTime?: number }
 ): Promise<{ jobId: string }> {
   return apiFetch(`/projects/${projectId}/export`, {
     method: 'POST',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,5 +1,11 @@
 // ─── Project / EDL ──────────────────────────────────────────────────────────
 
+export interface WorkArea {
+  start: number;    // seconds – start of work area
+  end: number;      // seconds – end of work area
+  isManual: boolean; // false = auto-stretch to project duration
+}
+
 export interface Project {
   id: string;
   name: string;
@@ -8,6 +14,7 @@ export interface Project {
   outputResolution: { w: number; h: number };
   tracks: Track[];
   lyrics?: LyricsData;
+  workArea?: WorkArea;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary

All done. Here's a summary of what was implemented:

**Work area (in/out range) for the timeline:**

1. **Visual bar on timeline** — the top 8px of the ruler now shows a teal-colored work area strip. Areas outside the work area (both ruler and tracks) are dimmed with a semi-transparent overlay.

2. **Draggable handles** — at the start and end of the work area, downward-pointing triangle handles can be dragged left/right (ew-resize cursor). Hovering near a handle takes priority over the regular seek click.

3. **Auto-stretch behavior** — when the work area is not manually set (`isManual: false`), it automatically stretches its end to match the project duration whenever clips are added/trimmed. Once the user manually drags either handle, `isManual` is set to `true` and auto-stretch stops.

4. **Playback respect** — `usePlayback` now stops at `workArea.end` instead of `project.duration`, and loops restart from `workArea.start`.

5. **Export range** — clicking Export passes `startTime`/`endTime` from the work area to the API, and `ffmpegService` adds `-ss <start> -t <duration>` to the ffmpeg command so only the selected range is encoded.

## Commits

- feat: add work area bar with draggable in/out handles to timeline