### PR TITLE
Kddyz video je spustene, tak ten gradient, ukazujici progress videa se neaktulizuje... aktulizuje se az pri stopnuti zas

### DIFF
--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -534,6 +534,7 @@ export default function Editor() {
             onToggle={playback.toggle}
             onLoopToggle={playback.toggleLoop}
             onSeek={playback.seek}
+            getTime={playback.getTime}
           />
 
           {/* Preview */}


### PR DESCRIPTION
## Summary

Opraveno. Byly dvě příčiny problému:

1. **`AudioContext.currentTime` nemusí vždy postupovat** — pokud prohlížeč suspenduje audio kontext (autoplay policy, tab v pozadí apod.), `elapsed` zůstává nula a `setCurrentTime` se nikdy nevolá. Opraveno přechodem na `performance.now()`, které vždy tikne.

2. **React 18 batch/defer rendering** — `setCurrentTime` spouštěný z RAF callbacku je v concurrent mode odložen, takže UI nemusí dostat nové hodnoty na každý snímek. Opraveno tak, že `TransportControls` má vlastní lokální RAF loop, který čte `getTime()` (přes `performance.now()`) a přímo mutuje DOM (šířka progress baru, pozice scrubber tečky, časový displej) — zcela mimo React render cyklus, takže vždy plynulých 60 fps.

## Commits

- fix: update progress gradient in real time during playback
- feat: add work area bar with draggable in/out handles to timeline
- feat: auto-detect new deploys and notify users with version banner