### PR TITLE
Dve veci: zaprve zparava ze je dostupna onva verze s eukazuje, i kdyz jsme danou verzi videli.... a za druhe.... ten pos

### DIFF
--- a/apps/web/src/hooks/usePlayback.ts
+++ b/apps/web/src/hooks/usePlayback.ts
@@ -237,10 +237,15 @@ export function usePlayback(
     if (isPlayingRef.current) {
       pause();
     } else {
-      // If at or past the work area end, restart from work area start
+      // Start from work area start when:
+      // - at or past the work area end (restart after finishing), OR
+      // - before the work area start (so 00:00 in display always = interval start in preview)
       const stopAt = workAreaRef.current?.end ?? duration;
       const restartFrom = workAreaRef.current?.start ?? 0;
-      if (stopAt > 0 && currentTimeRef.current >= stopAt - 0.05) {
+      if (
+        (stopAt > 0 && currentTimeRef.current >= stopAt - 0.05) ||
+        currentTimeRef.current < restartFrom
+      ) {
         currentTimeRef.current = restartFrom;
         setCurrentTime(restartFrom);
       }


### PR DESCRIPTION
## Summary

Hotovo. Zde jsou změny:

**1. Version banner (`useVersionCheck.ts`)** — Dismissed server build ID se teď ukládá do `localStorage`, takže banner "Dostupná nová verze" zůstane zavřený i po obnovení stránky. Dřív se ref resetoval při každém načtení stránky a banner se znovu objevoval.

**2. Preview alignment (`usePlayback.ts`)** — Při stisknutí Play se teď vždy skočí na `workArea.start`, pokud je `currentTime` před začátkem intervalu. Takže `00:00:00` v preview vždy odpovídá začátku nastaveného intervalu — stejně jako se chová export.

**3. Vstupní pole pro interval** — Tato pole (start a end) **už existují** v `TransportControls.tsx` — je to řádek pod seek barem s labelem „Interval", kde se dají přímo psát číselné časy. Jsou viditelná vždy, když je projekt načten.

## Commits

- fix: persist dismissed version banner and align preview to work area start
- feat: relative preview time + interval inputs + version banner fix