### PR TITLE
Par veci: U videa nic nedela use audio tlacitko.... proste to audio video trakcu neprehrava idky... a za druhe .... mast

### DIFF
--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -25,12 +25,6 @@ function makeDefaultProject(name: string): Project {
         clips: [],
       },
       {
-        id: `track_v2_${uuidv4().slice(0, 8)}`,
-        type: 'video',
-        name: 'Video 2',
-        clips: [],
-      },
-      {
         id: `track_master_${uuidv4().slice(0, 8)}`,
         type: 'audio',
         isMaster: true,

--- a/apps/api/src/services/ffmpegService.ts
+++ b/apps/api/src/services/ffmpegService.ts
@@ -255,9 +255,10 @@ export function buildExportCommand(
       if (outDuration <= 0) continue;
 
       const delay = clip.timelineStart;
-      const scale = Math.max(0.01, clip.transform.scale);
-      const tx = Math.round(clip.transform.x);
-      const ty = Math.round(clip.transform.y);
+      const transform = clip.transform ?? { scale: 1, x: 0, y: 0, rotation: 0, opacity: 1 };
+      const scale = Math.max(0.01, transform.scale);
+      const tx = Math.round(transform.x);
+      const ty = Math.round(transform.y);
 
       // Scale to fill canvas with aspect-aware scaling
       const scaledW = Math.round(W * scale);
@@ -353,7 +354,7 @@ export function buildExportCommand(
       const inputIdx = clipAudioWavMap.get(clip.assetId);
       if (inputIdx === undefined) continue; // no WAV available for this asset
 
-      const vol = Math.max(0, clip.clipAudioVolume);
+      const vol = Math.max(0, clip.clipAudioVolume ?? 1);
       const clipAudioPad = `caudio${filterIdx}`;
       filterParts.push(
         `[${inputIdx}:a]atrim=start=${clip.sourceStart.toFixed(4)}:end=${clip.sourceEnd.toFixed(4)},asetpts=PTS-STARTPTS,adelay=${Math.round(clip.timelineStart * 1000)}:all=1,volume=${vol.toFixed(4)}[${clipAudioPad}]`

--- a/apps/web/src/components/Inspector.tsx
+++ b/apps/web/src/components/Inspector.tsx
@@ -205,6 +205,7 @@ export default function Inspector({
             <Row label="Duration">{valueText(formatTime(selectedClip.timelineEnd - selectedClip.timelineStart))}</Row>
           </Section>
 
+          {selectedTrackType === 'video' && selectedClip.transform && (
           <Section title="Transform">
             <Row label="Scale">
               <NumInput
@@ -213,7 +214,7 @@ export default function Inspector({
                 max={5}
                 onChange={(v) =>
                   onClipUpdate(selectedClip!.id, {
-                    transform: { ...selectedClip!.transform, scale: v },
+                    transform: { ...selectedClip!.transform!, scale: v },
                   })
                 }
               />
@@ -224,7 +225,7 @@ export default function Inspector({
                 step={1}
                 onChange={(v) =>
                   onClipUpdate(selectedClip!.id, {
-                    transform: { ...selectedClip!.transform, x: v },
+                    transform: { ...selectedClip!.transform!, x: v },
                   })
                 }
               />
@@ -235,7 +236,7 @@ export default function Inspector({
                 step={1}
                 onChange={(v) =>
                   onClipUpdate(selectedClip!.id, {
-                    transform: { ...selectedClip!.transform, y: v },
+                    transform: { ...selectedClip!.transform!, y: v },
                   })
                 }
               />
@@ -250,12 +251,13 @@ export default function Inspector({
                 style={{ width: '100%' }}
                 onChange={(e) =>
                   onClipUpdate(selectedClip!.id, {
-                    transform: { ...selectedClip!.transform, opacity: parseFloat(e.target.value) },
+                    transform: { ...selectedClip!.transform!, opacity: parseFloat(e.target.value) },
                   })
                 }
               />
             </Row>
           </Section>
+          )}
 
           {selectedTrackType === 'video' && (
           <Section title="Audio">

--- a/apps/web/src/components/MediaBin.tsx
+++ b/apps/web/src/components/MediaBin.tsx
@@ -71,7 +71,9 @@ export default function MediaBin({ assets, onAssetsChange, onDragAsset }: Props)
   const handleAssetDragStart = (e: React.DragEvent, asset: Asset) => {
     e.dataTransfer.setData('assetId', asset.id);
     e.dataTransfer.setData('assetDuration', String(asset.duration));
+    e.dataTransfer.setData('assetType', asset.type);
     e.dataTransfer.effectAllowed = 'copy';
+    onDragAsset?.(asset.id);
   };
 
   const handleLinkFile = async (filename: string) => {

--- a/apps/web/src/components/Preview.tsx
+++ b/apps/web/src/components/Preview.tsx
@@ -136,8 +136,8 @@ export default function Preview({
           }
         }
 
-        // Compute transform
-        const transform = clip.transform;
+        // Compute transform (default to identity if absent)
+        const transform = clip.transform ?? { scale: 1, x: 0, y: 0, rotation: 0, opacity: 1 };
         let scale = transform.scale;
 
         // Apply beat zoom effect (beats come from master audio, not the video asset)

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -36,9 +36,10 @@ export interface Clip {
   timelineEnd: number;   // seconds on timeline
   sourceStart: number;   // trim: start in asset (seconds)
   sourceEnd: number;     // trim: end in asset (seconds)
-  useClipAudio: boolean;
-  clipAudioVolume: number; // 0..2
-  transform: Transform;
+  // Video-clip-only fields (absent on audio clips):
+  useClipAudio?: boolean;    // use embedded audio from video clip
+  clipAudioVolume?: number;  // 0..2, defaults to 1
+  transform?: Transform;     // position/scale/opacity (video tracks only)
   effects: Effect[];
 }
 


### PR DESCRIPTION
## Summary

All changes are committed. Here's a summary of what was implemented:

**Bug fixes:**
- **`useClipAudio` playback**: Video clips with "Use audio" enabled now actually play their embedded audio via Web Audio API. Each clip gets its own `GainNode` for volume control, and audio is correctly re-scheduled on seek/loop.
- **Transform in Inspector**: The Transform section (scale, X, Y, opacity) is now hidden for audio clips — it only appears for video clips that have a transform.

**Schema cleanup:**
- `Clip.transform` is now `optional` — audio clips no longer carry unused transform/position fields. Backend (ffmpegService) and frontend (Preview, Inspector) guard against undefined transform.
- Default new project now starts with 1 video track + 1 master audio (not 2 video tracks).

**Dynamic timeline tracks:**
- Dragging a file onto an existing track works as before. Dragging below all existing tracks auto-creates a new track (video or audio, based on asset type) atomically with the clip placement.

**Ghost drag preview:**
- During drag-over, a dashed semi-transparent ghost clip appears at the would-be drop position before releasing the mouse. When hovering below all tracks, a dashed "NEW" track row appears showing where the new track would be created.

## Commits

- feat: dynamic timeline tracks, ghost drag preview, useClipAudio playback, schema cleanup