### PR TITLE
Porad se mi ukazuje ze je dostupna nova verze, ikdyz uz novou verzi mame nactenou a pracujeme v ni

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -2,7 +2,13 @@
 
 // Generate a unique build ID at build time — changes automatically on every
 // `next build` so clients can detect when a new deploy is available.
-const buildId = Date.now().toString();
+//
+// In `next dev` mode Next.js always sets __NEXT_DATA__.buildId to the fixed
+// string "development" (it ignores generateBuildId entirely). If we used a
+// timestamp here, NEXT_BUILD_ID and __NEXT_DATA__.buildId would never match,
+// causing a perpetual false-positive "update available" banner in dev mode.
+const buildId =
+  process.env.NODE_ENV === 'development' ? 'development' : Date.now().toString();
 
 const nextConfig = {
   reactStrictMode: false, // disabled to avoid double-mount issues with WebAudio

--- a/apps/web/src/hooks/useVersionCheck.ts
+++ b/apps/web/src/hooks/useVersionCheck.ts
@@ -60,6 +60,12 @@ export function useVersionCheck(): { status: VersionStatus; dismiss: () => void 
     localStorage.setItem(VERSION_KEY, currentBuildId);
 
     // ── New-deploy polling ─────────────────────────────────────────────────────
+    // In Next.js dev mode (`next dev`), buildId is always the string
+    // 'development'. NEXT_BUILD_ID is also forced to 'development' via
+    // next.config.mjs, but we guard here too so dev builds never show
+    // a false-positive "update available" banner.
+    if (currentBuildId === 'development') return;
+
     const checkServerVersion = async () => {
       try {
         const res = await fetch('/app-version', { cache: 'no-store' });


### PR DESCRIPTION
## Summary

**Příčina**: V `next dev` módu Next.js vždy nastavuje `__NEXT_DATA__.buildId` na pevný string `"development"` a ignoruje funkci `generateBuildId`. Přitom `NEXT_BUILD_ID` byl nastavený na `Date.now()` timestamp — tyto hodnoty se nikdy neshodovaly, takže polling každých 60 sekund detekoval "novou verzi" i bez jakékoli změny.

**Oprava**: V `next.config.mjs` se nyní v dev módu používá `'development'` jako build ID (stejná hodnota jako co Next.js vkládá do stránky). V `useVersionCheck.ts` byl přidán i defenzivní guard `if (currentBuildId === 'development') return`, aby se polling přeskočil úplně. Přidán i test pokrývající toto chování.

## Commits

- fix: suppress false-positive "update available" banner in dev mode
- fix: progress bar now updates in real time during playback