### PR TITLE
Video track jde prodluzovat na zacatku i kdyz uz nema delsi zacatek... video se tam pak nejak opakuje... to nechci... tr

### DIFF
--- a/apps/web/src/components/Timeline.tsx
+++ b/apps/web/src/components/Timeline.tsx
@@ -790,13 +790,16 @@ export default function Timeline({
         }
         if (!clip) return;
 
+        // Earliest possible timelineStart is when sourceStart would reach 0
+        const minTimelineStart = Math.max(0, clip.timelineStart - clip.sourceStart);
+
         const snapTargets = getSnapTargets(d.clipId);
         const snapThreshold = SNAP_THRESHOLD_PX / Z;
         t = snap(t, snapTargets, snapThreshold);
-        t = clamp(t, 0, clip.timelineEnd - 0.1);
+        t = clamp(t, minTimelineStart, clip.timelineEnd - 0.1);
 
         const dt = t - clip.timelineStart;
-        onClipUpdate(d.clipId, { timelineStart: t, sourceStart: clip.sourceStart + dt });
+        onClipUpdate(d.clipId, { timelineStart: t, sourceStart: Math.max(0, clip.sourceStart + dt) });
         return;
       }
 


### PR DESCRIPTION
## Summary

Oprava je hotova. Problém byl v `Timeline.tsx` na řádku 796 — při táhnutí levého handle se `timelineStart` omezoval jen na `0`, ale nebyla žádná kontrola, jestli `sourceStart` neklesne pod 0 (tj. za začátek zdrojového materiálu). To způsobovalo opakování/loopu videa.

**Co bylo opraveno:**
- Vypočítá se `minTimelineStart = clip.timelineStart - clip.sourceStart` — nejdřívější možný začátek, kdy `sourceStart` by byl právě 0
- `t` se ořízne na `clamp(t, minTimelineStart, ...)` místo pouhého `clamp(t, 0, ...)`
- `sourceStart` se navíc clampuje na `Math.max(0, ...)` jako pojistka

Track v timeline teď nepůjde prodloužit dál, než kde skutečně začíná zdrojový soubor.

## Commits

- fix: prevent trimLeft from extending clip past source material boundary