### PR TITLE
STale blbe funguje to ukazovani zpravy Dostupna nova verze... obnovit. .... ukazujese mi to i kdyz dam obnovit a refresh

### DIFF
--- a/apps/web/src/__tests__/VersionBanner.test.tsx
+++ b/apps/web/src/__tests__/VersionBanner.test.tsx
@@ -47,8 +47,8 @@ describe('VersionBanner', () => {
     expect(screen.getByRole('button', { name: /obnovit/i })).toBeDefined();
   });
 
-  it('"Obnovit" button calls window.location.reload()', () => {
-    mockVersionCheck('update-available');
+  it('"Obnovit" button calls dismiss() and window.location.reload()', () => {
+    const { dismiss } = mockVersionCheck('update-available');
     const reloadMock = vi.fn();
     Object.defineProperty(window, 'location', {
       value: { ...window.location, reload: reloadMock },
@@ -57,6 +57,10 @@ describe('VersionBanner', () => {
 
     render(<VersionBanner />);
     fireEvent.click(screen.getByRole('button', { name: /obnovit/i }));
+    // dismiss() must be called first so the dismissed buildId is persisted
+    // to localStorage before the page reloads – otherwise the banner can
+    // reappear when the browser serves a cached old page after reload.
+    expect(dismiss).toHaveBeenCalledOnce();
     expect(reloadMock).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/src/components/VersionBanner.tsx
+++ b/apps/web/src/components/VersionBanner.tsx
@@ -86,7 +86,7 @@ export default function VersionBanner() {
           Dostupná nová verze
         </span>
         <button
-          onClick={() => window.location.reload()}
+          onClick={() => { dismiss(); window.location.reload(); }}
           style={{
             background: 'linear-gradient(135deg, #00d4a0, #38bdf8)',
             border: 'none',


### PR DESCRIPTION
## Summary

**Root cause:** Tlačítko "Obnovit" volalo `window.location.reload()`, ale nevolalo `dismiss()` - takže dismissed buildId se nikdy neuložil do localStorage. Pokud prohlížeč po reloadu natáhl starý cache HTML (se starým buildId), polling po 10 sekundách znovu detekoval rozdíl oproti serverovému buildId a banner se znovu zobrazil.

**Fix:** Přidáno volání `dismiss()` před `window.location.reload()`, takže dismissed buildId se uloží do localStorage dříve než stránka znovu načte - a banner se ani z cache stránky znovu neobjeví.

## Commits

- fix: call dismiss() before reload in VersionBanner to prevent banner reappearing