### PR TITLE
Uprava video transformu v previe wsekci docela funguje... ale tak napul... selection rectangle neni video mimo hranice v

### DIFF
--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -126,6 +126,7 @@ export default function Editor() {
     removeEffect,
     updateEffect,
     findClip,
+    reorderTrack,
   } = projectHook;
 
   const [assets, setAssets] = useState<Asset[]>([]);
@@ -824,6 +825,7 @@ export default function Editor() {
               onDropAsset={(trackId, assetId, start, dur) => addClip(trackId, assetId, start, dur)}
               onDropAssetNewTrack={handleDropAssetNewTrack}
               onWorkAreaChange={handleWorkAreaChange}
+              onTrackReorder={reorderTrack}
             />
           </div>
         </div>

--- a/apps/web/src/hooks/useProject.ts
+++ b/apps/web/src/hooks/useProject.ts
@@ -305,6 +305,19 @@ export function useProject() {
     [project]
   );
 
+  // Reorder tracks by index
+  const reorderTrack = useCallback(
+    (fromIdx: number, toIdx: number) => {
+      updateProject((p) => {
+        const tracks = [...p.tracks];
+        const [moved] = tracks.splice(fromIdx, 1);
+        tracks.splice(toIdx, 0, moved);
+        return { ...p, tracks };
+      });
+    },
+    [updateProject]
+  );
+
   return {
     project,
     setProject,
@@ -322,5 +335,6 @@ export function useProject() {
     removeEffect,
     updateEffect,
     findClip,
+    reorderTrack,
   };
 }


### PR DESCRIPTION
## Summary

Hotovo. Tady je souhrn co bylo implementováno:

**Výběrový obdélník (selection rect) mimo hranice:** Nahrazen canvas kreslením za SVG overlay s `overflow: visible`, takže handles (úchyty) jsou viditelné i mimo canvas. Přidány document-level event listenery pro `mousemove`/`mouseup`, takže lze s transformem manipulovat i po přetažení kurzoru mimo preview oblast.

**Kliknutí na text v preview pro výběr:** Přepracována logika `handleMouseDown` — nyní se nejdříve testují všechny viditelné clipsny od nejvyššího (text nad videem), a teprve pak se rozhoduje o pohybu. Text hit-area rozšířena o padding pro pohodlnější kliknutí.

**Pořadí vykreslování dle timeline:** Preview nyní iteruje `project.tracks` v jejich pořadí (ne video-první, text-poslední), takže pořadí vrstev v preview odpovídá pořadí řádků v timeline. Přidány drag-grip ikony na hlavičky tracků v timeline pro jejich přesouvání — stačí přetáhnout a řádky se přeřadí jak v timeline, tak v preview.

## Commits

- feat: selection SVG overlay, click-to-select fix, track z-order & reordering
- feat: add snap mode selector to timeline
- fix: call dismiss() before reload in VersionBanner to prevent banner reappearing
- fix: prevent trimLeft from extending clip past source material boundary