### PR TITLE
Chci aby se efekty pridavali trosku jinak... konkretne tak, ze se nebude efekt jen zapinat pri oznacenem videu... ale ze

### DIFF
--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -41,6 +41,8 @@ export default function Editor() {
     updateProject,
     addTrack,
     addTextTrack,
+    addEffectTrack,
+    updateEffectClipConfig,
     addClip,
     updateClip,
     deleteClip,
@@ -515,6 +517,10 @@ export default function Editor() {
           onDropAssetNewTrack={handleDropAssetNewTrack}
           onWorkAreaChange={handleWorkAreaChange}
           onTrackReorder={(fromIdx, toIdx) => reorderTrack(fromIdx, toIdx)}
+          onAddEffectTrack={(effectType, start, dur) => {
+            const clipId = addEffectTrack(effectType, start, dur);
+            setSelectedClipId(clipId);
+          }}
         />
       </div>
     ),
@@ -529,6 +535,7 @@ export default function Editor() {
           onAddEffect={addEffect}
           onRemoveEffect={removeEffect}
           onUpdateEffect={updateEffect}
+          onUpdateEffectClipConfig={updateEffectClipConfig}
           onUpdateProject={updateProject}
           masterAssetId={masterAssetId}
           onAlignLyrics={handleAlignLyrics}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -21,11 +21,12 @@ export interface Project {
 
 export interface Track {
   id: string;
-  type: 'video' | 'audio' | 'text';
+  type: 'video' | 'audio' | 'text' | 'effect';
   isMaster?: boolean; // master audio track
   name: string;
   muted?: boolean;
   clips: Clip[];
+  effectType?: 'beatZoom' | 'cutout'; // only for 'effect' tracks
 }
 
 export interface TextStyle {
@@ -55,6 +56,21 @@ export interface Clip {
   // Text-clip-only fields:
   textContent?: string;      // text to display (text tracks only)
   textStyle?: TextStyle;     // text appearance (text tracks only)
+  // Effect track clip fields:
+  effectConfig?: EffectClipConfig; // only for clips on 'effect' tracks
+}
+
+// Configuration stored on each clip that lives on an 'effect' track
+export interface EffectClipConfig {
+  effectType: 'beatZoom' | 'cutout';
+  enabled: boolean;
+  // beatZoom params
+  intensity?: number;   // fraction e.g. 0.08 = +8%
+  durationMs?: number;  // pulse duration ms
+  easing?: 'linear' | 'easeOut' | 'easeIn' | 'easeInOut';
+  // cutout params
+  background?: BackgroundConfig;
+  maskStatus?: 'pending' | 'processing' | 'done' | 'error';
 }
 
 export interface Transform {


### PR DESCRIPTION
## Summary

Implementace je hotová. Zde je shrnutí co bylo přidáno:

**Effect tracky jako vlastní typ tracku:**
- Nový typ tracku `'effect'` v timeline — zobrazuje se jako tenký proužek (26px vs 56px u video/audio)
- Efektové clopy mají oranžovo-jantarový vzhled (BeatZoom) nebo fialový (Cutout) se šrafovaným vzorem
- Pořadí efektů na video se určuje jejich vertikálním pořadím v timeline (přetažením track headeru)

**"Add Effect" tlačítko v toolbaru timeline:**
- Tlačítko `✦ Add Effect` vpravo nahoře v toolbaru timeline
- Rozklikne dropdown s volbou ⚡ Beat Zoom nebo ✂ Cutout
- Přidá nový effect track na pozici playheadu a vybere ho

**Přetahování a nastavení:**
- Effect clopy lze přetahovat po timeline (posun, trim z krajů) stejně jako ostatní clopy
- Když je vybraný effect clip, video clopy pod ním se zvýrazní oranžovým overlay
- Inspector zobrazí "Effect Settings" panel s nastavením: enabled, intensity, duration, easing (BeatZoom) nebo background color (Cutout)

## Commits

- feat: add effect tracks as a first-class timeline track type
- feat: show running/queued task counts on feedback button
- feat: replace linear panel reorder with full VS-Code-style docking layout
- feat: add Head Stabilization and Cartoon effects