### PR TITLE
Uprav v timeline ... aby linie beatu se ukazovali jen tehdy pokud mame zaply magnet beats

### DIFF
--- a/apps/web/src/components/Timeline.tsx
+++ b/apps/web/src/components/Timeline.tsx
@@ -388,7 +388,7 @@ export default function Timeline({
     // ─── Beat markers on ruler ─────────────────────────────────────────────
     const masterTrack = project.tracks.find((t) => t.type === 'audio' && t.isMaster);
     const masterClip = masterTrack?.clips[0];
-    if (masterClip) {
+    if (masterClip && snapModeRef.current === 'beats') {
       const beats = beatsData.get(masterClip.assetId);
       if (beats) {
         ctx.fillStyle = 'rgba(0, 212, 160, 0.60)';
@@ -508,7 +508,7 @@ export default function Timeline({
       }
 
       // Beat markers on tracks
-      if (masterClip) {
+      if (masterClip && snapModeRef.current === 'beats') {
         const beats = beatsData.get(masterClip.assetId);
         if (beats) {
           ctx.fillStyle = isEffectTrack ? 'rgba(251,146,60,0.20)' : 'rgba(0, 212, 160, 0.15)';


### PR DESCRIPTION
## Summary

Hotovo. Přidal jsem podmínku `snapModeRef.current === 'beats'` ke dvěma místům v timeline canvasu — na pravítku (ruler) i na těle každé stopy — takže beat linie se nyní zobrazují pouze tehdy, když je aktivní režim "Beats" v magnetu. Při "Off" nebo "Clips" jsou beat markery skryté.

## Commits

- feat: show beat lines in timeline only when magnet beats mode is active