### PR TITLE
Pridej strance nejakou ikonu do metadata, favicon

### DIFF
--- a/apps/web/src/app/icon.svg
+++ b/apps/web/src/app/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dark background -->
+  <rect width="32" height="32" rx="6" fill="#0e1a2e"/>
+  <!-- Clapperboard top (clapper strip) -->
+  <rect x="5" y="7" width="22" height="6" rx="1.5" fill="#00d4a0"/>
+  <!-- Diagonal stripes on clapper -->
+  <line x1="11" y1="7" x2="8"  y2="13" stroke="#0e1a2e" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="17" y1="7" x2="14" y2="13" stroke="#0e1a2e" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="23" y1="7" x2="20" y2="13" stroke="#0e1a2e" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Clapperboard body -->
+  <rect x="5" y="13" width="22" height="13" rx="2" fill="#162438" stroke="#00d4a0" stroke-width="1.5"/>
+  <!-- Play triangle -->
+  <polygon points="13,17 13,23 21,20" fill="#00d4a0"/>
+</svg>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,6 +6,9 @@ import VersionBanner from '@/components/VersionBanner';
 export const metadata: Metadata = {
   title: 'Video Editor',
   description: 'Local fast video editor for music shorts',
+  icons: {
+    icon: '/icon.svg',
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary

Hotovo. Přidal jsem clapperboard SVG ikonu (`apps/web/src/app/icon.svg`) v barvách projektu — teal `#00d4a0` na tmavém navy pozadí `#0e1a2e` — s diagonálními pruhy a play trojúhelníkem. Next.js App Router ji automaticky rozpozná jako favicon díky umístění přímo v `app/` adresáři, a metadata v `layout.tsx` byly doplněny o explicitní `icons.icon` odkaz pro jistotu.

## Commits

- feat: add clapperboard SVG favicon to web app metadata