### PR TITLE
head stabilisation efekt nefunguje... pri zmacknuti tlacitka process to pise... ze nebyl naelze zadny parent clip

### DIFF
--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -268,7 +268,7 @@ export default function Editor() {
     const effectTrack = project.tracks.find((t) => t.clips.some((c) => c.id === clipId));
     const parentTrack = effectTrack?.parentTrackId
       ? project.tracks.find((t) => t.id === effectTrack.parentTrackId)
-      : undefined;
+      : project.tracks.find((t) => t.type === 'video');
     const videoClips = parentTrack?.clips ?? [];
     const seenAssets = new Set<string>();
     const uniqueAssetIds = videoClips.map((c) => c.assetId).filter((id) => id && !seenAssets.has(id) && seenAssets.add(id));
@@ -304,7 +304,7 @@ export default function Editor() {
     const effectTrack = project.tracks.find((t) => t.clips.some((c) => c.id === clipId));
     const parentTrack = effectTrack?.parentTrackId
       ? project.tracks.find((t) => t.id === effectTrack.parentTrackId)
-      : undefined;
+      : project.tracks.find((t) => t.type === 'video');
     const videoClips = parentTrack?.clips ?? [];
     const seenAssets = new Set<string>();
     const uniqueAssetIds = videoClips.map((c) => c.assetId).filter((id) => id && !seenAssets.has(id) && seenAssets.add(id));

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -92,6 +92,32 @@ export interface Transform {
   opacity: number;  // 0..1
 }
 
+// ─── Typed effect descriptors (used by effect panel components) ─────────────
+
+export interface CartoonEffect {
+  type: 'cartoon';
+  enabled: boolean;
+  edgeStrength: number;
+  colorSimplification: number;
+  saturation: number;
+}
+
+export interface CutoutEffect {
+  type: 'cutout';
+  enabled: boolean;
+  background: BackgroundConfig;
+  maskStatus?: 'pending' | 'processing' | 'done' | 'error';
+}
+
+export interface HeadStabilizationEffect {
+  type: 'headStabilization';
+  enabled: boolean;
+  smoothingX: number;
+  smoothingY: number;
+  smoothingZ: number;
+  status?: 'pending' | 'processing' | 'done' | 'error';
+}
+
 // ─── Background config (used by cutout effect in EffectClipConfig) ──────────
 
 export interface BackgroundConfig {


### PR DESCRIPTION
## Summary

The root cause was in `Editor.tsx`: both `handleStartHeadStabilization` and `handleStartCutout` used `effectTrack?.parentTrackId ? ... : undefined`, meaning if `parentTrackId` was not set on the effect track (e.g. on older projects), no parent track was found and the error fired. The fix adds a fallback to `project.tracks.find((t) => t.type === 'video')` when `parentTrackId` is missing.

Two pre-existing build errors were also fixed: `Preview.tsx` was calling `clip.effects.find()` which doesn't exist on the `Clip` type (replaced with proper effect-track lookup matching the beat zoom pattern), and three missing effect type interfaces (`CartoonEffect`, `CutoutEffect`, `HeadStabilizationEffect`) were added to the shared package.

## Commits

- fix: head stabilization 'no parent clip' error and pre-existing build failures