### PR TITLE
dej zprava z inspectoru pryc ten lyrics option a export option... export staci ze je globalne v project sekci... a lryci

### DIFF
--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -41,6 +41,7 @@ export default function Editor() {
     updateProject,
     addTrack,
     addTextTrack,
+    addLyricsTrack,
     addEffectTrack,
     updateEffectClipConfig,
     addClip,
@@ -247,12 +248,13 @@ export default function Editor() {
     finally { setBeatsProgress(null); setBeatsLogLine(null); }
   };
 
-  const handleAlignLyrics = async (text: string) => {
+  const handleAlignLyricsClip = async (clipId: string, text: string) => {
     if (!project) return;
     notify('Starting lyrics alignment...');
     try {
-      const { jobId } = await api.alignLyrics(project.id, text, masterAssetId);
+      const { jobId } = await api.alignLyricsClip(project.id, clipId, text, masterAssetId);
       await api.pollJob(jobId, (j) => notify(`Lyrics: ${j.progress}%`));
+      // Reload project to get updated lyricsWords on the clip
       const { project: updated } = await api.loadProject(project.id);
       setProject(updated);
       notify('Lyrics aligned!');
@@ -637,10 +639,9 @@ export default function Editor() {
           onUpdateEffectClipConfig={updateEffectClipConfig}
           onUpdateProject={updateProject}
           masterAssetId={masterAssetId}
-          onAlignLyrics={handleAlignLyrics}
+          onAlignLyricsClip={handleAlignLyricsClip}
           onStartCutout={handleStartCutout}
           onStartHeadStabilization={handleStartHeadStabilization}
-          onExport={handleExport}
           onSyncAudio={masterAssetId ? handleSyncAudio : undefined}
         />
       </div>
@@ -792,6 +793,28 @@ export default function Editor() {
             WebkitTextFillColor: 'transparent',
           }}>T</span>
           Add Text
+        </button>
+
+        <button
+          className="btn btn-ghost"
+          style={{ fontSize: 13, display: 'flex', alignItems: 'center', gap: 6, opacity: project ? 1 : 0.4 }}
+          disabled={!project}
+          title="Add a lyrics track to the timeline"
+          onClick={() => {
+            if (!project) return;
+            const start = playback.currentTime;
+            const duration = 10;
+            const clipId = addLyricsTrack(start, duration);
+            setSelectedClipId(clipId);
+          }}
+        >
+          <span style={{
+            fontSize: 14, fontWeight: 700,
+            background: 'linear-gradient(135deg, #c084fc, #818cf8)',
+            WebkitBackgroundClip: 'text',
+            WebkitTextFillColor: 'transparent',
+          }}>♪</span>
+          Add Lyrics
         </button>
       </div>
 

--- a/apps/web/src/hooks/useProject.ts
+++ b/apps/web/src/hooks/useProject.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import type { Project, Clip, Track, Transform, TextStyle, EffectClipConfig, EffectType } from '@video-editor/shared';
+import type { Project, Clip, Track, Transform, TextStyle, EffectClipConfig, EffectType, LyricsStyle } from '@video-editor/shared';
 import * as api from '@/lib/api';
 import { genId } from '@/lib/utils';
 
@@ -236,6 +236,48 @@ export function useProject() {
     [updateProject]
   );
 
+  // Add a lyrics track with one clip at timelineStart
+  const addLyricsTrack = useCallback(
+    (timelineStart: number, duration: number, text: string = '') => {
+      const trackId = genId('track');
+      const clipId = genId('clip');
+      const defaultStyle: LyricsStyle = {
+        fontSize: 48,
+        color: '#ffffff',
+        highlightColor: '#FFE600',
+        position: 'bottom',
+        wordsPerChunk: 3,
+      };
+      updateProject((p) => {
+        const count = p.tracks.filter((t) => t.type === 'lyrics').length;
+        const newTrack: Track = {
+          id: trackId,
+          type: 'lyrics',
+          name: `Lyrics ${count + 1}`,
+          muted: false,
+          clips: [
+            {
+              id: clipId,
+              assetId: '',
+              trackId,
+              timelineStart,
+              timelineEnd: timelineStart + duration,
+              sourceStart: 0,
+              sourceEnd: duration,
+              lyricsContent: text,
+              lyricsStyle: defaultStyle,
+              lyricsAlignStatus: 'idle',
+              transform: { ...DEFAULT_TRANSFORM },
+            },
+          ],
+        };
+        return { ...p, tracks: [...p.tracks, newTrack] };
+      });
+      return clipId;
+    },
+    [updateProject]
+  );
+
   // Add clip to track
   const addClip = useCallback(
     (trackId: string, assetId: string, timelineStart: number, duration: number) => {
@@ -362,6 +404,7 @@ export function useProject() {
     updateProject,
     addTrack,
     addTextTrack,
+    addLyricsTrack,
     addEffectTrack,
     updateEffectClipConfig,
     addClip,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -111,6 +111,19 @@ export async function alignLyrics(
   });
 }
 
+export async function alignLyricsClip(
+  projectId: string,
+  clipId: string,
+  text: string,
+  audioAssetId?: string
+): Promise<{ jobId: string }> {
+  return apiFetch(`/projects/${projectId}/clips/${clipId}/align-lyrics`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text, audioAssetId }),
+  });
+}
+
 export async function exportProject(
   projectId: string,
   opts?: { width?: number; height?: number; crf?: number; preset?: string; startTime?: number; endTime?: number }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -23,7 +23,7 @@ export type EffectType = 'beatZoom' | 'cutout' | 'headStabilization' | 'cartoon'
 
 export interface Track {
   id: string;
-  type: 'video' | 'audio' | 'text' | 'effect';
+  type: 'video' | 'audio' | 'text' | 'lyrics' | 'effect';
   isMaster?: boolean; // master audio track
   name: string;
   muted?: boolean;
@@ -58,6 +58,11 @@ export interface Clip {
   // Text-clip-only fields:
   textContent?: string;      // text to display (text tracks only)
   textStyle?: TextStyle;     // text appearance (text tracks only)
+  // Lyrics-clip-only fields:
+  lyricsContent?: string;    // full lyrics text (lyrics tracks only)
+  lyricsWords?: WordTimestamp[];  // word-level timestamps from Whisper (lyrics tracks only)
+  lyricsStyle?: LyricsStyle; // lyrics appearance (lyrics tracks only)
+  lyricsAlignStatus?: 'idle' | 'aligning' | 'done' | 'error'; // alignment job status
   // Effect track clip fields:
   effectConfig?: EffectClipConfig; // only for clips on 'effect' tracks
 }


### PR DESCRIPTION
## Summary

Done. Here's a summary of what was implemented:

**Lyrics as a proper track type:**
- Added an **"Add Lyrics" button** to the editor toolbar (next to "Add Text") — creates a lyrics track with a 10-second clip starting at the current playhead position
- Lyrics clips appear on the timeline in a distinct **purple color** with a `♪ "text..."` label

**Inspector for lyrics clips:**
- When a lyrics clip is selected, the Inspector shows the full `LyricsClipInspector` UI: text input to paste lyrics, "Align with Whisper" button, word count feedback, and style controls (font size, colors, position, words-per-chunk)
- Transform section is also available to reposition the lyrics overlay

**Export removed from Inspector:** Export lives exclusively in the ProjectBar — the `onExport` prop was removed from Inspector and the `onAlignLyrics` prop was corrected to `onAlignLyricsClip` (per-clip signature).

**Backend:** Added a new `POST /projects/:id/clips/:clipId/align-lyrics` endpoint that runs Whisper alignment and writes the resulting word timestamps back to the specific clip's `lyricsWords` field in the project JSON.

## Commits

- feat: redesign lyrics as a proper track type with Whisper alignment per clip