### PR TITLE
Na mobile se to nejak divne zobrazuje. Zobrazuje se to jen v leve casti obrazovky, napravo je prazdno

### DIFF
--- a/apps/web/src/components/MobileLayout.tsx
+++ b/apps/web/src/components/MobileLayout.tsx
@@ -70,7 +70,7 @@ export function MobileLayout({ panelRenderers }: { panelRenderers: PanelRenderer
   const [activeTab, setActiveTab] = useState<MobileTab>('preview');
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%', overflow: 'hidden' }}>
 
       {/* ── Content area ─────────────────────────────────────────────────── */}
       <div style={{ flex: 1, minHeight: 0, position: 'relative', overflow: 'hidden' }}>


### PR DESCRIPTION
## Summary

Příčina problému: rodičovský kontejner v `Editor.tsx` používá `display: flex` (flex row), ale `MobileLayout` neměl nastavené `width: 100%`. V flex row layoutu se potomci nerozprostírají automaticky na plnou šířku hlavní osy – zabrali jen šířku svého obsahu, takže pravá část obrazovky zůstala prázdná.

Oprava: přidání `width: '100%'` do root divu v `MobileLayout.tsx` (řádek 73). Build prošel úspěšně – při té příležitosti jsem také přebuiloval shared package, jehož zastaralý dist soubor způsoboval TypeScript chybu v `Inspector.tsx`.

## Commits

- fix: mobile layout stretches to full width on small screens
- refactor: simplify timeline rows to video/audio only and merge text into video tracks