### PR TITLE
Na mobile nefunguje preview spravne... obcas to nic neukazuje.... rovnou take prosim fixni aby spodni lista s zalozkami 

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -10,7 +10,8 @@
 
 html,
 body {
-  height: 100%;
+  height: 100vh; /* fallback */
+  height: 100dvh; /* dynamic viewport height — excludes browser UI on mobile */
   overflow: hidden;
   color: #e8f4f0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -21,7 +21,7 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body style={{ height: '100vh', overflow: 'hidden' }}>
+      <body style={{ height: '100dvh', overflow: 'hidden' }}>
         {children}
         <VersionBanner />
         <FeedbackButton />

--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -673,7 +673,7 @@ export default function Editor() {
 
   // ── Main editor layout ─────────────────────────────────────────────────────
   return (
-    <div className="flex flex-col h-screen overflow-hidden">
+    <div className="flex flex-col overflow-hidden" style={{ height: '100dvh' }}>
 
       {/* ── Top bar ─────────────────────────────────────────────────────── */}
       <div

--- a/apps/web/src/components/MobileLayout.tsx
+++ b/apps/web/src/components/MobileLayout.tsx
@@ -75,14 +75,18 @@ export function MobileLayout({ panelRenderers }: { panelRenderers: PanelRenderer
       {/* ── Content area ─────────────────────────────────────────────────── */}
       <div style={{ flex: 1, minHeight: 0, position: 'relative', overflow: 'hidden' }}>
 
-        {/* Preview tab: project-bar + preview + transport stacked */}
+        {/* Preview tab: project-bar + preview + transport stacked.
+            Uses visibility instead of display:none so the container keeps its
+            dimensions — ResizeObserver inside Preview fires reliably on tab switch. */}
         <div
           style={{
             position: 'absolute',
             inset: 0,
-            display: activeTab === 'preview' ? 'flex' : 'none',
+            display: 'flex',
             flexDirection: 'column',
             overflow: 'hidden',
+            visibility: activeTab === 'preview' ? 'visible' : 'hidden',
+            pointerEvents: activeTab === 'preview' ? 'auto' : 'none',
           }}
         >
           {/* Project bar (compact) */}

--- a/apps/web/src/components/Preview.tsx
+++ b/apps/web/src/components/Preview.tsx
@@ -724,6 +724,8 @@ export default function Preview({
 
     const ro = new ResizeObserver(() => {
       const { clientWidth, clientHeight } = container;
+      // Skip when container is hidden (display:none / visibility:hidden collapses to 0)
+      if (clientWidth === 0 || clientHeight === 0) return;
       const aspect = project
         ? project.outputResolution.w / project.outputResolution.h
         : 9 / 16;


### PR DESCRIPTION
## Summary

Oba problémy opraveny:

1. **Spodní lišta se záložkami** — nahradil jsem `100vh` za `100dvh` (dynamic viewport height) v `globals.css`, `layout.tsx` i `Editor.tsx`. `100dvh` se přizpůsobuje aktuálně viditelnému viewportu a nebere v úvahu browser chrome (adresní lišta, spodní navigace), takže záložkový panel bude vždy celý viditelný.

2. **Preview neukazuje nic** — v `MobileLayout.tsx` přepínám preview panel místo `display:none/flex` na `visibility:hidden/visible` + `pointerEvents`. Panel tak zůstává celou dobu v layoutu, `ResizeObserver` uvnitř `Preview.tsx` dostává správné rozměry bez ohledu na aktivní záložku. Jako pojistka jsem přidal guard v `ResizeObserver` callbacku, který přeskočí resize při nulových rozměrech.

## Commits

- fix(mobile): fix tab bar cut off and preview blank on mobile