### PR TITLE
Dej moznost prepinat tmavy a svetly mod... Oboje at vypada moderne

### DIFF
--- a/apps/web/src/__tests__/useTheme.test.tsx
+++ b/apps/web/src/__tests__/useTheme.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTheme } from '../hooks/useTheme';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+// Mock matchMedia
+function mockMatchMedia(prefersDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: prefersDark && query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', { value: localStorageMock, writable: true });
+    localStorageMock.clear();
+    document.documentElement.classList.remove('dark');
+    mockMatchMedia(false);
+  });
+
+  afterEach(() => {
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('defaults to light mode when no preference is stored', () => {
+    const { result } = renderHook(() => useTheme());
+    // After effect runs
+    expect(result.current.theme).toBe('light');
+    expect(result.current.isDark).toBe(false);
+  });
+
+  it('reads stored dark theme from localStorage', () => {
+    localStorageMock.setItem('video-editor-theme', 'dark');
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe('dark');
+    expect(result.current.isDark).toBe(true);
+  });
+
+  it('reads stored light theme from localStorage', () => {
+    localStorageMock.setItem('video-editor-theme', 'light');
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe('light');
+    expect(result.current.isDark).toBe(false);
+  });
+
+  it('respects system dark preference when nothing is stored', () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe('dark');
+    expect(result.current.isDark).toBe(true);
+  });
+
+  it('toggleTheme switches from light to dark', () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe('light');
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(result.current.theme).toBe('dark');
+    expect(result.current.isDark).toBe(true);
+    expect(localStorageMock.getItem('video-editor-theme')).toBe('dark');
+  });
+
+  it('toggleTheme switches from dark to light', () => {
+    localStorageMock.setItem('video-editor-theme', 'dark');
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(result.current.theme).toBe('light');
+    expect(result.current.isDark).toBe(false);
+    expect(localStorageMock.getItem('video-editor-theme')).toBe('light');
+  });
+
+  it('toggleTheme adds dark class to document element', () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('toggleTheme removes dark class when switching to light', () => {
+    localStorageMock.setItem('video-editor-theme', 'dark');
+    document.documentElement.classList.add('dark');
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('persists theme across multiple toggles', () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => { result.current.toggleTheme(); }); // light -> dark
+    expect(result.current.theme).toBe('dark');
+
+    act(() => { result.current.toggleTheme(); }); // dark -> light
+    expect(result.current.theme).toBe('light');
+
+    act(() => { result.current.toggleTheme(); }); // light -> dark
+    expect(result.current.theme).toBe('dark');
+
+    expect(localStorageMock.getItem('video-editor-theme')).toBe('dark');
+  });
+});

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2,6 +2,76 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ─── CSS Custom Properties ──────────────────────────────────────────────── */
+
+:root {
+  /* Surfaces */
+  --surface-bg:         #f0f4f8;
+  --surface-raised:     #ffffff;
+  --surface-topbar:     rgba(255,255,255,0.95);
+  --surface-projectbar: rgba(255,255,255,0.90);
+  --surface-glass:      rgba(255,255,255,0.85);
+  --surface-panel:      rgba(255,255,255,0.92);
+  --surface-hover:      rgba(15,23,42,0.04);
+  --surface-overlay:    rgba(15,23,42,0.03);
+
+  /* Text */
+  --text-primary:   #0f172a;
+  --text-secondary: rgba(15,23,42,0.60);
+  --text-muted:     rgba(15,23,42,0.40);
+  --text-subtle:    rgba(15,23,42,0.35);
+
+  /* Borders */
+  --border-subtle:  rgba(15,23,42,0.07);
+  --border-default: rgba(15,23,42,0.12);
+  --border-strong:  rgba(15,23,42,0.20);
+
+  /* Inputs */
+  --input-bg:       #ffffff;
+  --input-bg-hover: #fafafa;
+
+  /* Scrollbars */
+  --scrollbar-thumb:       rgba(15,23,42,0.15);
+  --scrollbar-thumb-hover: rgba(15,23,42,0.28);
+
+  /* Progress bars track */
+  --progress-track: rgba(15,23,42,0.08);
+}
+
+.dark {
+  /* Surfaces */
+  --surface-bg:         #0f172a;
+  --surface-raised:     #1e293b;
+  --surface-topbar:     rgba(15,23,42,0.96);
+  --surface-projectbar: rgba(15,23,42,0.92);
+  --surface-glass:      rgba(30,41,59,0.88);
+  --surface-panel:      rgba(30,41,59,0.94);
+  --surface-hover:      rgba(226,232,240,0.05);
+  --surface-overlay:    rgba(226,232,240,0.04);
+
+  /* Text */
+  --text-primary:   #e2e8f0;
+  --text-secondary: rgba(226,232,240,0.65);
+  --text-muted:     rgba(226,232,240,0.42);
+  --text-subtle:    rgba(226,232,240,0.35);
+
+  /* Borders */
+  --border-subtle:  rgba(226,232,240,0.08);
+  --border-default: rgba(226,232,240,0.14);
+  --border-strong:  rgba(226,232,240,0.24);
+
+  /* Inputs */
+  --input-bg:       #1e293b;
+  --input-bg-hover: #273549;
+
+  /* Scrollbars */
+  --scrollbar-thumb:       rgba(226,232,240,0.18);
+  --scrollbar-thumb-hover: rgba(226,232,240,0.35);
+
+  /* Progress bars track */
+  --progress-track: rgba(226,232,240,0.10);
+}
+
 * {
   box-sizing: border-box;
   margin: 0;
@@ -13,10 +83,11 @@ body {
   height: 100vh; /* fallback */
   height: 100dvh; /* dynamic viewport height — excludes browser UI on mobile */
   overflow: hidden;
-  color: #0f172a;
+  color: var(--text-primary);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-size: 14px;
-  background: #f0f4f8;
+  background: var(--surface-bg);
+  transition: background 0.25s ease, color 0.25s ease;
 }
 
 #__next { height: 100%; }
@@ -96,22 +167,34 @@ body {
   from { opacity: 0; transform: translateY(-8px); }
   to   { opacity: 1; transform: translateY(0); }
 }
+@keyframes themePop {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(0.88) rotate(-15deg); }
+  100% { transform: scale(1) rotate(0deg); }
+}
 
 /* ─── Scrollbar ──────────────────────────────────────────────────────────── */
 ::-webkit-scrollbar        { width: 5px; height: 5px; }
 ::-webkit-scrollbar-track  { background: transparent; }
-::-webkit-scrollbar-thumb  { background: rgba(15,23,42,0.15); border-radius: 6px; }
-::-webkit-scrollbar-thumb:hover { background: rgba(15,23,42,0.28); }
+::-webkit-scrollbar-thumb  { background: var(--scrollbar-thumb); border-radius: 6px; }
+::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 
 /* ─── Glass panel ─────────────────────────────────────────────────────────── */
 .glass {
-  background: rgba(255, 255, 255, 0.85);
+  background: var(--surface-glass);
   backdrop-filter: blur(20px) saturate(1.4);
   -webkit-backdrop-filter: blur(20px) saturate(1.4);
-  border: 1px solid rgba(15, 23, 42, 0.07);
+  border: 1px solid var(--border-subtle);
   box-shadow:
     0 1px 3px rgba(15,23,42,0.06),
     0 8px 24px rgba(15,23,42,0.05);
+  transition: background 0.25s ease, border-color 0.25s ease;
+}
+
+.dark .glass {
+  box-shadow:
+    0 1px 3px rgba(0,0,0,0.20),
+    0 8px 24px rgba(0,0,0,0.15);
 }
 
 /* ─── Gradient text ─────────────────────────────────────────────────────── */
@@ -168,13 +251,13 @@ body {
 
 .btn-ghost {
   @apply bg-transparent;
-  color: #475569;
+  color: var(--text-secondary);
   border: 1px solid transparent;
 }
 .btn-ghost:hover {
-  background: rgba(15,23,42,0.06);
-  border-color: rgba(15,23,42,0.10);
-  color: #0f172a;
+  background: var(--surface-hover);
+  border-color: var(--border-default);
+  color: var(--text-primary);
   transform: translateY(-1px);
   box-shadow: 0 1px 4px rgba(15,23,42,0.06);
 }
@@ -185,13 +268,20 @@ body {
 
 /* ─── Panel ───────────────────────────────────────────────────────────────── */
 .panel {
-  background: rgba(255, 255, 255, 0.92);
+  background: var(--surface-panel);
   backdrop-filter: blur(16px) saturate(1.3);
   -webkit-backdrop-filter: blur(16px) saturate(1.3);
-  border-color: rgba(15, 23, 42, 0.07);
+  border-color: var(--border-subtle);
   box-shadow:
     0 1px 2px rgba(15,23,42,0.04),
     inset 0 1px 0 rgba(255,255,255,0.80);
+  transition: background 0.25s ease, border-color 0.25s ease;
+}
+
+.dark .panel {
+  box-shadow:
+    0 1px 2px rgba(0,0,0,0.20),
+    inset 0 1px 0 rgba(255,255,255,0.04);
 }
 
 /* ─── Form inputs ────────────────────────────────────────────────────────── */
@@ -201,12 +291,12 @@ input[type="text"],
 input[type="number"],
 textarea,
 select {
-  background: #ffffff;
-  border: 1px solid rgba(15,23,42,0.12);
+  background: var(--input-bg);
+  border: 1px solid var(--border-default);
   border-radius: 8px;
   padding: 8px 12px;
   font-size: 13px;
-  color: #0f172a;
+  color: var(--text-primary);
   outline: none;
   width: 100%;
   transition: border-color 0.2s, box-shadow 0.2s, background 0.2s, transform 0.15s;
@@ -215,16 +305,21 @@ input[type="text"]:hover,
 input[type="number"]:hover,
 textarea:hover,
 select:hover {
-  background: #fafafa;
-  border-color: rgba(15,23,42,0.20);
+  background: var(--input-bg-hover);
+  border-color: var(--border-strong);
 }
 input[type="text"]:focus,
 input[type="number"]:focus,
 textarea:focus,
 select:focus {
-  background: #ffffff;
+  background: var(--input-bg);
   border-color: rgba(13,148,136,0.55);
   box-shadow: 0 0 0 3px rgba(13,148,136,0.10);
+}
+
+/* Dark mode select arrow */
+.dark select {
+  color-scheme: dark;
 }
 
 /* ─── Resize handles ─────────────────────────────────────────────────────── */
@@ -317,6 +412,14 @@ select:focus {
 .animate-spin-slow { animation: spinSlow 8s linear infinite; }
 .animate-fade-in { animation: fadeIn 0.3s ease forwards; }
 .animate-slide-down { animation: slideDown 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) forwards; }
+
+/* ─── Theme toggle button animation ─────────────────────────────────────── */
+.theme-toggle-icon {
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.2s ease;
+}
+.theme-toggle-btn:active .theme-toggle-icon {
+  animation: themePop 0.3s ease;
+}
 
 /* ─── Mobile responsive overrides ─────────────────────────────────────────── */
 @media (max-width: 767px) {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import FeedbackButton from '@/components/FeedbackButton';
 import VersionBanner from '@/components/VersionBanner';
+import { ThemeProvider } from '@/contexts/ThemeContext';
 
 export const metadata: Metadata = {
   title: 'Video Editor',
@@ -21,10 +22,29 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
+      {/* Inline script prevents flash of wrong theme on page load */}
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+(function() {
+  try {
+    var stored = localStorage.getItem('video-editor-theme');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var theme = stored || (prefersDark ? 'dark' : 'light');
+    if (theme === 'dark') document.documentElement.classList.add('dark');
+  } catch(e) {}
+})();
+            `,
+          }}
+        />
+      </head>
       <body style={{ height: '100dvh', overflow: 'hidden' }}>
-        {children}
-        <VersionBanner />
-        <FeedbackButton />
+        <ThemeProvider>
+          {children}
+          <VersionBanner />
+          <FeedbackButton />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -14,6 +14,7 @@ import TransportControls from './TransportControls';
 import ProjectBar from './ProjectBar';
 import { DockLayout } from './DockLayout';
 import { MobileLayout } from './MobileLayout';
+import { useThemeContext } from '@/contexts/ThemeContext';
 
 // ─── Responsive breakpoint ────────────────────────────────────────────────────
 
@@ -48,6 +49,7 @@ function pickLogLine(lines: string[]): string | null {
 
 export default function Editor() {
   const isMobile = useIsMobile();
+  const { isDark, toggleTheme } = useThemeContext();
   const projectHook = useProject();
   const {
     project,
@@ -412,20 +414,36 @@ export default function Editor() {
   // ── Project picker ─────────────────────────────────────────────────────────
   if (showProjectPicker) {
     return (
-      <div className="h-screen flex items-center justify-center px-4" style={{ background: 'inherit', position: 'relative', overflow: 'hidden' }}>
-        {/* Animated background orbs */}
-        <div className="bg-orb bg-orb-1" />
-        <div className="bg-orb bg-orb-2" />
-        <div className="bg-orb bg-orb-3" />
-
+      <div className="h-screen flex items-center justify-center px-4" style={{ background: 'var(--surface-bg)', position: 'relative', overflow: 'hidden' }}>
         {/* Subtle grid pattern */}
         <div style={{
           position: 'absolute', inset: 0,
-          backgroundImage: 'radial-gradient(circle, rgba(15,23,42,0.05) 1px, transparent 1px)',
+          backgroundImage: `radial-gradient(circle, ${isDark ? 'rgba(226,232,240,0.05)' : 'rgba(15,23,42,0.05)'} 1px, transparent 1px)`,
           backgroundSize: '40px 40px',
           pointerEvents: 'none',
           animation: 'fadeIn 1.2s ease forwards',
         }} />
+
+        {/* Theme toggle — top right */}
+        <button
+          className="theme-toggle-btn"
+          onClick={toggleTheme}
+          title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+          style={{
+            position: 'absolute', top: 16, right: 16,
+            width: 36, height: 36, borderRadius: 10,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: 'var(--surface-hover)',
+            border: '1px solid var(--border-subtle)',
+            cursor: 'pointer',
+            color: 'var(--text-secondary)',
+            transition: 'all 0.2s ease',
+          }}
+        >
+          <span className="theme-toggle-icon" style={{ fontSize: 16, lineHeight: 1 }}>
+            {isDark ? '☀' : '◑'}
+          </span>
+        </button>
 
         <div
           className="glass rounded-2xl w-full shadow-panel scale-in"
@@ -463,7 +481,7 @@ export default function Editor() {
               </div>
               <h1 className="text-3xl font-bold text-gradient">Video Editor</h1>
             </div>
-            <p className="text-sm" style={{ color: 'rgba(15,23,42,0.45)', paddingLeft: 48 }}>Craft your story, frame by frame</p>
+            <p className="text-sm" style={{ color: 'var(--text-muted)', paddingLeft: 48 }}>Craft your story, frame by frame</p>
           </div>
 
           {/* New project */}
@@ -506,7 +524,7 @@ export default function Editor() {
               {/* Divider */}
               <div style={{
                 height: 1,
-                background: 'linear-gradient(90deg, transparent, rgba(15,23,42,0.08), transparent)',
+                background: `linear-gradient(90deg, transparent, var(--border-default), transparent)`,
                 marginBottom: 20,
               }} />
               <p className="text-xs font-semibold uppercase tracking-widest" style={{ color: 'rgba(13,148,136,0.75)', letterSpacing: '0.12em', marginBottom: 12 }}>Recent</p>
@@ -517,22 +535,22 @@ export default function Editor() {
                     className="w-full text-left rounded-xl stagger-item"
                     style={{
                       padding: '12px 14px',
-                      background: 'rgba(15,23,42,0.03)',
-                      border: '1px solid rgba(15,23,42,0.07)',
+                      background: 'var(--surface-overlay)',
+                      border: '1px solid var(--border-subtle)',
                       transition: 'all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1)',
                       animationDelay: `${0.24 + idx * 0.06}s`,
                     }}
                     onMouseEnter={(e) => {
                       const el = e.currentTarget as HTMLElement;
-                      el.style.background = 'rgba(13,148,136,0.06)';
+                      el.style.background = 'rgba(13,148,136,0.08)';
                       el.style.borderColor = 'rgba(13,148,136,0.22)';
                       el.style.transform = 'translateX(3px)';
                       el.style.boxShadow = '0 2px 8px rgba(15,23,42,0.06)';
                     }}
                     onMouseLeave={(e) => {
                       const el = e.currentTarget as HTMLElement;
-                      el.style.background = 'rgba(15,23,42,0.03)';
-                      el.style.borderColor = 'rgba(15,23,42,0.07)';
+                      el.style.background = 'var(--surface-overlay)';
+                      el.style.borderColor = 'var(--border-subtle)';
                       el.style.transform = '';
                       el.style.boxShadow = '';
                     }}
@@ -550,12 +568,12 @@ export default function Editor() {
                     }}
                   >
                     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                      <div className="text-sm font-semibold" style={{ color: '#0f172a' }}>{p.name}</div>
-                      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" style={{ opacity: 0.35, flexShrink: 0 }}>
+                      <div className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>{p.name}</div>
+                      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" style={{ opacity: 0.35, flexShrink: 0, color: 'var(--text-primary)' }}>
                         <path d="M5 3l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
                       </svg>
                     </div>
-                    <div className="text-xs mt-0.5" style={{ color: 'rgba(15,23,42,0.38)' }}>{new Date(p.updatedAt).toLocaleDateString()}</div>
+                    <div className="text-xs mt-0.5" style={{ color: 'var(--text-subtle)' }}>{new Date(p.updatedAt).toLocaleDateString()}</div>
                   </button>
                 ))}
               </div>
@@ -682,10 +700,12 @@ export default function Editor() {
           height: isMobile ? 48 : 56,
           padding: isMobile ? '0 12px' : '0 20px',
           gap: isMobile ? 8 : 16,
-          background: 'rgba(255,255,255,0.95)',
+          background: 'var(--surface-topbar)',
           backdropFilter: 'blur(20px)',
-          borderColor: 'rgba(15,23,42,0.08)',
-          boxShadow: '0 1px 3px rgba(15,23,42,0.06), 0 2px 8px rgba(15,23,42,0.04)',
+          borderColor: 'var(--border-subtle)',
+          boxShadow: isDark
+            ? '0 1px 3px rgba(0,0,0,0.20), 0 2px 8px rgba(0,0,0,0.15)'
+            : '0 1px 3px rgba(15,23,42,0.06), 0 2px 8px rgba(15,23,42,0.04)',
         }}
       >
         {/* Logo mark + title */}
@@ -718,9 +738,9 @@ export default function Editor() {
             className="flex items-center gap-1.5 rounded-md px-2.5 py-1 transition-all"
             style={{
               fontSize: 12,
-              color: saving ? 'rgba(15,23,42,0.38)' : '#0d9488',
-              background: saving ? 'rgba(15,23,42,0.04)' : 'rgba(13,148,136,0.08)',
-              border: `1px solid ${saving ? 'rgba(15,23,42,0.08)' : 'rgba(13,148,136,0.22)'}`,
+              color: saving ? 'var(--text-muted)' : '#0d9488',
+              background: saving ? 'var(--surface-hover)' : 'rgba(13,148,136,0.08)',
+              border: `1px solid ${saving ? 'var(--border-subtle)' : 'rgba(13,148,136,0.22)'}`,
               letterSpacing: '0.01em',
               transition: 'all 0.35s cubic-bezier(0.4,0,0.2,1)',
               boxShadow: saving ? 'none' : '0 0 8px rgba(13,148,136,0.10)',
@@ -767,6 +787,29 @@ export default function Editor() {
 
         <div className="flex-1" />
 
+        {/* Theme toggle */}
+        <button
+          className="theme-toggle-btn"
+          onClick={toggleTheme}
+          title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+          style={{
+            width: isMobile ? 32 : 34,
+            height: isMobile ? 32 : 34,
+            borderRadius: 8,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: 'var(--surface-hover)',
+            border: '1px solid var(--border-subtle)',
+            cursor: 'pointer',
+            color: 'var(--text-secondary)',
+            flexShrink: 0,
+            transition: 'all 0.2s ease',
+          }}
+        >
+          <span className="theme-toggle-icon" style={{ fontSize: 14, lineHeight: 1 }}>
+            {isDark ? '☀' : '◑'}
+          </span>
+        </button>
+
         {/* Projects button — always visible */}
         <button
           className="btn btn-ghost"
@@ -779,7 +822,7 @@ export default function Editor() {
         {/* Undo/Redo — hidden on mobile */}
         {!isMobile && (
           <>
-            <div className="w-px h-5" style={{ background: 'rgba(15,23,42,0.10)' }} />
+            <div className="w-px h-5" style={{ background: 'var(--border-default)' }} />
             <button
               className="btn btn-ghost disabled:opacity-25"
               style={{ fontSize: 18, padding: '4px 10px' }}
@@ -799,7 +842,7 @@ export default function Editor() {
               ↻
             </button>
 
-            <div className="w-px h-5" style={{ background: 'rgba(15,23,42,0.10)' }} />
+            <div className="w-px h-5" style={{ background: 'var(--border-default)' }} />
 
             <button
               className="btn btn-ghost"
@@ -872,7 +915,7 @@ export default function Editor() {
               style={{
                 width: 34, height: 34, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center',
                 background: 'none', border: 'none', cursor: 'pointer',
-                fontSize: 18, color: history.canUndo ? 'rgba(15,23,42,0.70)' : 'rgba(15,23,42,0.20)',
+                fontSize: 18, color: history.canUndo ? 'var(--text-secondary)' : 'var(--text-muted)',
                 touchAction: 'manipulation',
                 WebkitTapHighlightColor: 'transparent',
               } as React.CSSProperties}
@@ -884,7 +927,7 @@ export default function Editor() {
               style={{
                 width: 34, height: 34, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center',
                 background: 'none', border: 'none', cursor: 'pointer',
-                fontSize: 18, color: history.canRedo ? 'rgba(15,23,42,0.70)' : 'rgba(15,23,42,0.20)',
+                fontSize: 18, color: history.canRedo ? 'var(--text-secondary)' : 'var(--text-muted)',
                 touchAction: 'manipulation',
                 WebkitTapHighlightColor: 'transparent',
               } as React.CSSProperties}
@@ -916,7 +959,7 @@ export default function Editor() {
               className="glass rounded-xl shadow-panel toast-enter"
               style={{
                 minWidth: isMobile ? 'min(220px, calc(100vw - 24px))' : 296,
-                color: '#0f172a',
+                color: 'var(--text-primary)',
                 fontSize: 13,
                 padding: '12px 16px',
                 display: 'flex',

--- a/apps/web/src/components/ProjectBar.tsx
+++ b/apps/web/src/components/ProjectBar.tsx
@@ -70,13 +70,13 @@ export default function ProjectBar({
         gap: isMobile ? 8 : 12,
         padding: isMobile ? '0 12px' : '0 20px',
         flexShrink: 0,
-        borderBottom: '1px solid rgba(15,23,42,0.08)',
+        borderBottom: '1px solid var(--border-subtle)',
         userSelect: 'none',
         overflowX: 'auto',
         minHeight: isMobile ? 44 : 48,
-        background: 'rgba(255,255,255,0.90)',
+        background: 'var(--surface-projectbar)',
         backdropFilter: 'blur(16px)',
-        boxShadow: '0 1px 0 rgba(15,23,42,0.06)',
+        boxShadow: '0 1px 0 var(--border-subtle)',
         // Hide scrollbar but allow scroll on mobile
         scrollbarWidth: 'none',
       }}
@@ -90,17 +90,17 @@ export default function ProjectBar({
         </svg>
         {!isMobile && <span style={{ fontSize: 12, color: 'rgba(13,148,136,0.70)', fontWeight: 500 }}>Master</span>}
         {masterAsset ? (
-          <span style={{ fontSize: 12, fontWeight: 500, color: '#0f172a', maxWidth: isMobile ? 90 : 160, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--text-primary)', maxWidth: isMobile ? 90 : 160, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
             {masterAsset.name}
           </span>
         ) : (
-          <span style={{ fontSize: 12, fontStyle: 'italic', color: 'rgba(15,23,42,0.35)' }}>
+          <span style={{ fontSize: 12, fontStyle: 'italic', color: 'var(--text-subtle)' }}>
             {isMobile ? 'no audio' : 'no audio track'}
           </span>
         )}
       </div>
 
-      <div style={{ width: 1, height: 16, background: 'rgba(15,23,42,0.12)', flexShrink: 0 }} />
+      <div style={{ width: 1, height: 16, background: 'var(--border-default)', flexShrink: 0 }} />
 
       {/* Beat status / progress / analyze button */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
@@ -167,7 +167,7 @@ export default function ProjectBar({
         />
       ) : exportDone ? (
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
-          {!isMobile && <span style={{ fontSize: 13, color: 'rgba(13,148,136,0.70)' }}>Export done</span>}
+          {!isMobile && <span style={{ fontSize: 13, color: 'rgba(13,148,136,0.85)' }}>Export done</span>}
           <button
             style={{
               fontSize: isMobile ? 12 : 13,
@@ -242,7 +242,7 @@ function JobProgressBlock({
         <span style={{ fontSize: compact ? 11 : 13, flexShrink: 0, fontWeight: 500, color: primary }}>
           {label}
         </span>
-        <div style={{ position: 'relative', height: 4, borderRadius: 4, flex: 1, background: 'rgba(15,23,42,0.08)', minWidth: compact ? 40 : 80 }}>
+        <div style={{ position: 'relative', height: 4, borderRadius: 4, flex: 1, background: 'var(--progress-track)', minWidth: compact ? 40 : 80 }}>
           <div
             style={{
               position: 'absolute',

--- a/apps/web/src/contexts/ThemeContext.tsx
+++ b/apps/web/src/contexts/ThemeContext.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { createContext, useContext, ReactNode } from 'react';
+import { useTheme, Theme } from '@/hooks/useTheme';
+
+interface ThemeContextValue {
+  theme: Theme;
+  isDark: boolean;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  isDark: false,
+  toggleTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const themeValue = useTheme();
+  return (
+    <ThemeContext.Provider value={themeValue}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useThemeContext() {
+  return useContext(ThemeContext);
+}

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'video-editor-theme';
+
+function getSystemTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  if (theme === 'dark') {
+    root.classList.add('dark');
+  } else {
+    root.classList.remove('dark');
+  }
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    const initial = stored ?? getSystemTheme();
+    setTheme(initial);
+    applyTheme(initial);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => {
+      const next: Theme = prev === 'light' ? 'dark' : 'light';
+      localStorage.setItem(STORAGE_KEY, next);
+      applyTheme(next);
+      return next;
+    });
+  }, []);
+
+  return { theme, isDark: theme === 'dark', toggleTheme };
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,70 @@
+# Theming — Dark / Light Mode
+
+## Overview
+
+The app supports full dark/light mode switching with:
+- Automatic detection of the OS/browser preference (`prefers-color-scheme`)
+- Persistence across sessions via `localStorage` (`video-editor-theme`)
+- No flash-of-wrong-theme on page load (inline script in `<head>`)
+- Smooth `0.25s` transition on background and text colors
+
+## Architecture
+
+### CSS Custom Properties
+
+All color tokens are defined as CSS custom properties in `apps/web/src/app/globals.css`:
+
+```css
+:root {
+  --surface-bg, --surface-raised, --surface-topbar, ...
+  --text-primary, --text-secondary, --text-muted, --text-subtle
+  --border-subtle, --border-default, --border-strong
+  --input-bg, --input-bg-hover
+  --scrollbar-thumb, --scrollbar-thumb-hover
+  --progress-track
+}
+
+.dark {
+  /* dark mode overrides for all tokens */
+}
+```
+
+### Tailwind Dark Mode
+
+Configured as `darkMode: 'class'` in `tailwind.config.ts`. The `dark` class is applied to `<html>` by the `useTheme` hook.
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `apps/web/src/hooks/useTheme.ts` | Manages theme state, localStorage, `<html>` class |
+| `apps/web/src/contexts/ThemeContext.tsx` | React context provider; exposes `isDark`, `toggleTheme` |
+| `apps/web/src/app/layout.tsx` | Wraps app with `ThemeProvider`; includes anti-FOUC script |
+| `apps/web/src/app/globals.css` | CSS variable definitions for both themes |
+| `apps/web/tailwind.config.ts` | `darkMode: 'class'` configuration |
+
+### Using the Theme in Components
+
+```tsx
+import { useThemeContext } from '@/contexts/ThemeContext';
+
+function MyComponent() {
+  const { isDark, toggleTheme } = useThemeContext();
+
+  return (
+    <div style={{ background: 'var(--surface-bg)', color: 'var(--text-primary)' }}>
+      <button onClick={toggleTheme}>
+        {isDark ? '☀ Light' : '◑ Dark'}
+      </button>
+    </div>
+  );
+}
+```
+
+Prefer CSS variables (`var(--surface-bg)`) in inline styles where possible. Use `isDark` boolean for conditional logic (e.g., shadow colors, icon selection).
+
+### Toggle Button
+
+The theme toggle button (`◑` / `☀`) appears:
+- In the **top bar** of the main editor view (always visible)
+- In the **project picker** screen (top-right corner)


### PR DESCRIPTION
## Summary

The background build already completed successfully (exit code 0) — everything is good. The implementation is complete and committed.

Here's a quick summary of what was built:

**Dark/light mode toggle** was added using a CSS custom properties system + React context:
- A `◑` / `☀` toggle button appears in the **top bar** (always visible) and the **project picker** screen (top-right corner)
- The chosen theme persists in `localStorage` and respects the OS `prefers-color-scheme` setting on first visit
- An inline `<script>` in `<head>` prevents any flash of wrong theme on page load
- All color tokens (`--surface-bg`, `--text-primary`, `--border-subtle`, etc.) are defined as CSS variables and automatically switch between light and dark values when the `dark` class is applied to `<html>`

## Commits

- feat: add dark/light mode toggle with system preference detection
- feat: preview section dark grid background, white video canvas default