### PR TITLE
v preview sekci by mrizka by se mela posouvat a zoomovat spolu se zobrazovanym obsahem...

### DIFF
--- a/apps/web/src/components/Preview.tsx
+++ b/apps/web/src/components/Preview.tsx
@@ -1160,7 +1160,8 @@ export default function Preview({
         backgroundColor: '#1a1a2e',
         backgroundImage:
           'linear-gradient(rgba(255,255,255,0.07) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.07) 1px, transparent 1px)',
-        backgroundSize: '24px 24px',
+        backgroundSize: `${24 * viewZoom}px ${24 * viewZoom}px`,
+        backgroundPosition: `${viewPan.x}px ${viewPan.y}px`,
       }}
     >
       {/* Zoomable canvas wrapper — CSS transform for viewport zoom */}


### PR DESCRIPTION
## Summary

Jednoduchá oprava: `backgroundSize` mřížky se nyní násobí hodnotou `viewZoom` (takže buňky mřížky se zvětšují/zmenšují spolu s obsahem) a `backgroundPosition` se nastavuje na `viewPan.x / viewPan.y` (takže mřížka se posouvá stejně jako canvas). Tím mřížka vizuálně "drží krok" s přibližováním i posouváním zobrazovaného obsahu v preview.

## Commits

- fix: sync preview grid background with zoom and pan state