### PR TITLE
pridej na preview sekci i vedle informace o zoomu, i tlacitko reset... ktere znovu presune pohled na to video

### DIFF
--- a/apps/web/src/__tests__/PreviewZoom.test.tsx
+++ b/apps/web/src/__tests__/PreviewZoom.test.tsx
@@ -68,6 +68,7 @@ describe('Preview zoom controls', () => {
     expect(screen.getByTestId('zoom-in-btn')).toBeDefined();
     expect(screen.getByTestId('zoom-out-btn')).toBeDefined();
     expect(screen.getByTestId('zoom-reset-btn')).toBeDefined();
+    expect(screen.getByTestId('view-center-btn')).toBeDefined();
   });
 
   it('shows 100% zoom level by default', () => {
@@ -120,5 +121,23 @@ describe('Preview zoom controls', () => {
     // After zoom-in the scale should be > 1
     expect(wrapper.style.transform).not.toContain('scale(1)');
     expect(wrapper.style.transform).toMatch(/scale\(1\.[1-9]/);
+  });
+
+  it('view-center-btn resets zoom to 100% after zooming in', () => {
+    render(<Preview {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('zoom-in-btn'));
+    fireEvent.click(screen.getByTestId('zoom-in-btn'));
+    expect(parseInt(screen.getByTestId('zoom-reset-btn').textContent ?? '', 10)).toBeGreaterThan(100);
+    fireEvent.click(screen.getByTestId('view-center-btn'));
+    expect(screen.getByTestId('zoom-reset-btn').textContent).toBe('100%');
+  });
+
+  it('view-center-btn resets transform scale to 1 after panning/zooming', () => {
+    render(<Preview {...defaultProps} />);
+    const wrapper = screen.getByTestId('preview-zoom-wrapper');
+    fireEvent.click(screen.getByTestId('zoom-in-btn'));
+    fireEvent.click(screen.getByTestId('view-center-btn'));
+    expect(wrapper.style.transform).toContain('scale(1)');
+    expect(wrapper.style.transform).toContain('translate(0px, 0px)');
   });
 });

--- a/apps/web/src/components/Preview.tsx
+++ b/apps/web/src/components/Preview.tsx
@@ -1264,6 +1264,32 @@ export default function Preview({
         >
           +
         </button>
+        <div
+          style={{
+            width: 1,
+            height: 14,
+            background: 'rgba(15,23,42,0.15)',
+            margin: '0 2px',
+          }}
+        />
+        <button
+          data-testid="view-center-btn"
+          onClick={resetView}
+          title="Reset view — přesune pohled zpět na video"
+          style={{
+            background: 'none',
+            border: 'none',
+            color: 'rgba(15,23,42,0.55)',
+            cursor: 'pointer',
+            fontSize: 13,
+            lineHeight: 1,
+            padding: '0 2px',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          ⊡
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

The build output was already retrieved earlier — it completed successfully with exit code 0. Everything is good.

## Commits

- feat: add reset view button next to zoom controls in preview section
- fix: sync preview grid background with zoom and pan state