### PR TITLE
V timeline v nazvu radku u videa a master audia ... je tam videt uprostred nejaky divny znak... nadpis VIdeo a audio.. p

### DIFF
--- a/apps/web/src/components/Timeline.tsx
+++ b/apps/web/src/components/Timeline.tsx
@@ -1627,8 +1627,9 @@ export default function Timeline({
                 style={{
                   height: getTrackH(track),
                   display: 'flex',
-                  alignItems: 'center',
+                  alignItems: 'flex-end',
                   justifyContent: 'center',
+                  paddingBottom: '3px',
                   pointerEvents: 'auto',
                   cursor: 'grab',
                   opacity: trackDragFromIdx === idx ? 0 : 1,


### PR DESCRIPTION
## Summary

The SVG grip-dots icon (used as a drag handle for reordering tracks) was positioned with `alignItems: 'center'` — placing it exactly in the middle of the track header, directly on top of the canvas-drawn "VIDEO"/"AUDIO" label text. This caused the dots to appear as a strange character overlaid on the name.

The fix moves the grip icon to the bottom edge of the row (`alignItems: 'flex-end'`, `paddingBottom: '3px'`), so the label text is fully readable and the drag affordance dots appear unobtrusively at the bottom of each track header.

## Commits

- fix: move grip dots icon to bottom of track header to stop overlapping label text
- feat: fixed-height project-bar and transport panels with linked resize