### PR TITLE
text ktery v timeline je v radku nad radkem s videem se presto zobrazuje v preview pod videem. Udleej, aby se to opravdu

### DIFF
--- a/apps/api/src/services/ffmpegService.ts
+++ b/apps/api/src/services/ffmpegService.ts
@@ -290,8 +290,10 @@ export function buildExportCommand(
   filterParts.push(`color=c=black:s=${W}x${H}:r=30[base]`);
   let prevPad = 'base';
 
-  // Video clips
-  for (const track of videoTracks) {
+  // Video clips — iterate in reverse so that tracks higher in the timeline
+  // (lower array index) are overlaid last and therefore appear on top,
+  // matching the preview rendering order.
+  for (const track of [...videoTracks].reverse()) {
     for (const clip of track.clips) {
       const inputIdx = assetInputIdxMap.get(clip.assetId);
       if (inputIdx === undefined) continue;


### PR DESCRIPTION
## Summary

Opraveno ve třech místech. Iterace přes stopy v `Preview.tsx` byla otočena (`[...project.tracks].reverse()`), takže stopa nahoře v timeline (index 0) se vykreslí jako poslední a tedy se zobrazí nad ostatními. Hit-testing byl upraven stejně, aby klikání správně vybíralo horní vrstvu. Stejná oprava byla aplikována i v `ffmpegService.ts`, takže exportované video má shodné pořadí vrstev jako preview.

## Commits

- fix: reverse track rendering order to match timeline visual order
- fix: move grip dots icon to bottom of track header to stop overlapping label text
- feat: fixed-height project-bar and transport panels with linked resize