### PR TITLE
Dej ty tlaticka na pridani textu a lryics jinam... chtel bych mit vlevo od previeew nejakou sekci s tools ktere jdou pou

### DIFF
--- a/apps/web/src/components/DockLayout.tsx
+++ b/apps/web/src/components/DockLayout.tsx
@@ -217,6 +217,7 @@ const ZONE_STYLE: Record<DropZone, React.CSSProperties> = {
 
 const PANEL_LABELS: Record<string, string> = {
   media:          'Media',
+  tools:          'Tools',
   preview:        'Preview',
   inspector:      'Inspector',
   timeline:       'Timeline',
@@ -260,6 +261,7 @@ export const DEFAULT_LAYOUT: DockNode = {
   direction: 'h',
   children: [
     { type: 'leaf', id: 'leaf_media',      panelId: 'media' },
+    { type: 'leaf', id: 'leaf_tools',      panelId: 'tools' },
     {
       type: 'split',
       id: 'center',
@@ -274,10 +276,10 @@ export const DEFAULT_LAYOUT: DockNode = {
     },
     { type: 'leaf', id: 'leaf_inspector',  panelId: 'inspector' },
   ],
-  sizes: [0.20, 0.56, 0.24],
+  sizes: [0.18, 0.08, 0.50, 0.24],
 };
 
-const STORAGE_KEY = 've-dock-layout';
+const STORAGE_KEY = 've-dock-layout-v2';
 
 function loadLayout(): DockNode {
   try {

--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -12,6 +12,7 @@ import Timeline from './Timeline';
 import Inspector from './Inspector';
 import TransportControls from './TransportControls';
 import ProjectBar from './ProjectBar';
+import ToolsPanel from './ToolsPanel';
 import { DockLayout } from './DockLayout';
 import { MobileLayout } from './MobileLayout';
 import { useThemeContext } from '@/contexts/ThemeContext';
@@ -687,6 +688,21 @@ export default function Editor() {
         />
       </div>
     ),
+
+    tools: () => (
+      <ToolsPanel
+        project={project}
+        currentTime={playback.currentTime}
+        onAddText={(start, duration, text) => {
+          const clipId = addTextTrack(start, duration, text);
+          setSelectedClipId(clipId);
+        }}
+        onAddLyrics={(start, duration) => {
+          const clipId = addLyricsTrack(start, duration);
+          setSelectedClipId(clipId);
+        }}
+      />
+    ),
   };
 
   // ── Main editor layout ─────────────────────────────────────────────────────
@@ -841,76 +857,12 @@ export default function Editor() {
             >
               ↻
             </button>
-
-            <div className="w-px h-5" style={{ background: 'var(--border-default)' }} />
-
-            <button
-              className="btn btn-ghost"
-              style={{ fontSize: 13, display: 'flex', alignItems: 'center', gap: 6, opacity: project ? 1 : 0.4 }}
-              disabled={!project}
-              title="Add a text element to the timeline"
-              onClick={() => {
-                if (!project) return;
-                const start = playback.currentTime;
-                const duration = 3;
-                const clipId = addTextTrack(start, duration, 'Text');
-                setSelectedClipId(clipId);
-              }}
-            >
-              <span style={{ fontSize: 15, fontWeight: 700 }}>T</span>
-              Add Text
-            </button>
           </>
         )}
 
-        {/* Desktop: Add Lyrics button (Add Text is already in the !isMobile block above) */}
-        {!isMobile && (
-          <button
-            className="btn btn-ghost"
-            style={{ fontSize: 13, display: 'flex', alignItems: 'center', gap: 6, opacity: project ? 1 : 0.4 }}
-            disabled={!project}
-            title="Add a lyrics track to the timeline"
-            onClick={() => {
-              if (!project) return;
-              const start = playback.currentTime;
-              const duration = 10;
-              const clipId = addLyricsTrack(start, duration);
-              setSelectedClipId(clipId);
-            }}
-          >
-            <span style={{
-              fontSize: 14, fontWeight: 700,
-              background: 'linear-gradient(135deg, #c084fc, #818cf8)',
-              WebkitBackgroundClip: 'text',
-              WebkitTextFillColor: 'transparent',
-            }}>♪</span>
-            Add Lyrics
-          </button>
-        )}
-
-        {/* Mobile: compact Add Text + undo/redo icons */}
+        {/* Mobile: undo/redo icons */}
         {isMobile && (
           <>
-            {/* Add Text — compact icon button */}
-            <button
-              style={{
-                width: 34, height: 34, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center',
-                background: project ? 'rgba(13,148,136,0.08)' : 'none',
-                border: project ? '1px solid rgba(13,148,136,0.22)' : 'none',
-                cursor: 'pointer',
-                fontSize: 14, fontWeight: 700, color: project ? '#0d9488' : 'rgba(15,23,42,0.20)',
-                touchAction: 'manipulation',
-                WebkitTapHighlightColor: 'transparent',
-              } as React.CSSProperties}
-              disabled={!project}
-              title="Add Text"
-              onClick={() => {
-                if (!project) return;
-                const start = playback.currentTime;
-                const clipId = addTextTrack(start, 3, 'Text');
-                setSelectedClipId(clipId);
-              }}
-            >T</button>
             <button
               style={{
                 width: 34, height: 34, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center',

--- a/apps/web/src/components/ToolsPanel.tsx
+++ b/apps/web/src/components/ToolsPanel.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import React from 'react';
+import type { Project } from '@video-editor/shared';
+
+interface ToolsPanelProps {
+  project: Project | null;
+  currentTime: number;
+  onAddText: (start: number, duration: number, text: string) => void;
+  onAddLyrics: (start: number, duration: number) => void;
+}
+
+interface ToolItem {
+  id: string;
+  icon: React.ReactNode;
+  label: string;
+  description: string;
+  onClick: () => void;
+}
+
+export default function ToolsPanel({ project, currentTime, onAddText, onAddLyrics }: ToolsPanelProps) {
+  // Tools are only enabled when there's at least one video track with a real video clip
+  const hasVideoTrack = project?.tracks.some(
+    (t) => t.type === 'video' && t.clips.some((c) => !!c.assetId)
+  ) ?? false;
+
+  const tools: ToolItem[] = [
+    {
+      id: 'text',
+      icon: (
+        <span style={{ fontSize: 17, fontWeight: 800, fontFamily: 'serif', color: 'inherit' }}>
+          T
+        </span>
+      ),
+      label: 'Text',
+      description: 'Přidat textový overlay',
+      onClick: () => onAddText(currentTime, 3, 'Text'),
+    },
+    {
+      id: 'lyrics',
+      icon: (
+        <span style={{
+          fontSize: 16,
+          fontWeight: 700,
+          background: 'linear-gradient(135deg, #c084fc, #818cf8)',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          display: 'block',
+          lineHeight: 1,
+        }}>
+          ♪
+        </span>
+      ),
+      label: 'Lyrics',
+      description: 'Přidat lyrics track',
+      onClick: () => onAddLyrics(currentTime, 10),
+    },
+  ];
+
+  return (
+    <div style={{
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      padding: '10px 6px',
+      gap: 2,
+      overflowY: 'auto',
+      overflowX: 'hidden',
+    }}>
+      {/* Section header */}
+      <div style={{
+        fontSize: 9,
+        fontWeight: 700,
+        letterSpacing: '0.09em',
+        textTransform: 'uppercase',
+        color: 'var(--text-muted)',
+        padding: '2px 6px 8px',
+        borderBottom: '1px solid var(--border-subtle)',
+        marginBottom: 6,
+        userSelect: 'none',
+      }}>
+        Přidat prvek
+      </div>
+
+      {/* Tool buttons */}
+      {tools.map((tool) => (
+        <ToolButton
+          key={tool.id}
+          icon={tool.icon}
+          label={tool.label}
+          description={tool.description}
+          enabled={hasVideoTrack}
+          onClick={tool.onClick}
+        />
+      ))}
+
+      {/* Divider */}
+      <div style={{ borderTop: '1px solid var(--border-subtle)', margin: '8px 4px' }} />
+
+      {/* Video – drag hint */}
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 4,
+        padding: '10px 4px',
+        borderRadius: 8,
+        opacity: 0.55,
+        userSelect: 'none',
+        cursor: 'default',
+      }}>
+        <div style={{
+          width: 34,
+          height: 34,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          borderRadius: 8,
+          background: 'var(--surface-hover)',
+          border: '1px solid var(--border-subtle)',
+          flexShrink: 0,
+        }}>
+          <VideoIcon />
+        </div>
+        <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-secondary)' }}>
+          Video
+        </span>
+        <span style={{
+          fontSize: 10,
+          color: 'var(--text-muted)',
+          lineHeight: 1.5,
+          textAlign: 'center',
+        }}>
+          Přetáhni<br />z Media panelu
+        </span>
+      </div>
+
+      {/* No video warning */}
+      {!hasVideoTrack && project && (
+        <div style={{
+          marginTop: 'auto',
+          padding: '8px 6px',
+          borderRadius: 6,
+          background: 'rgba(234,179,8,0.08)',
+          border: '1px solid rgba(234,179,8,0.20)',
+          fontSize: 10,
+          color: 'rgba(234,179,8,0.85)',
+          textAlign: 'center',
+          lineHeight: 1.5,
+          userSelect: 'none',
+        }}>
+          Nejprve přidej<br />video do timeline
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── ToolButton ───────────────────────────────────────────────────────────────
+
+function ToolButton({
+  icon,
+  label,
+  description,
+  enabled,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  description: string;
+  enabled: boolean;
+  onClick: () => void;
+}) {
+  const [hovered, setHovered] = React.useState(false);
+
+  return (
+    <button
+      disabled={!enabled}
+      onClick={onClick}
+      title={enabled ? description : 'Nejprve přidej video do timeline'}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 5,
+        padding: '10px 4px',
+        borderRadius: 8,
+        border: `1px solid ${hovered && enabled ? 'var(--border-default)' : 'transparent'}`,
+        background: hovered && enabled ? 'var(--surface-hover)' : 'transparent',
+        cursor: enabled ? 'pointer' : 'not-allowed',
+        opacity: enabled ? 1 : 0.35,
+        transition: 'background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease',
+        width: '100%',
+        minHeight: 62,
+        color: hovered && enabled ? 'var(--text-primary)' : 'var(--text-secondary)',
+        userSelect: 'none',
+        WebkitTapHighlightColor: 'transparent',
+      } as React.CSSProperties}
+    >
+      <div style={{
+        width: 34,
+        height: 34,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: 8,
+        background: hovered && enabled ? 'var(--surface-base)' : 'var(--surface-hover)',
+        border: '1px solid var(--border-subtle)',
+        transition: 'background 0.15s ease',
+        flexShrink: 0,
+      }}>
+        {icon}
+      </div>
+      <span style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.01em' }}>
+        {label}
+      </span>
+    </button>
+  );
+}
+
+// ─── Icons ────────────────────────────────────────────────────────────────────
+
+function VideoIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" style={{ color: 'var(--text-secondary)' }}>
+      <rect x="1" y="3" width="10" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M11 6.2L14.5 4.5v7L11 9.8" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Hotovo. Implementoval jsem tyto změny:

- **Nový `ToolsPanel` komponent** — úzký sidebar vlevo od preview s tlačítky **Text** a **Lyrics**, plus neklickatelná sekce **Video** s popiskem "Přetáhni z Media panelu". Tlačítka jsou disabled, pokud v timeline není žádný video clip s reálným assetem (zobrazí se také žlutá hláška).
- **Editor.tsx** — tlačítka "Add Text" a "Add Lyrics" odstraněna z top baru, nový panel `tools` přidán do `panelRenderers`.
- **DockLayout.tsx** — tools panel zařazen do `DEFAULT_LAYOUT` mezi Media a Preview (šířka ~8 %), storage key změněn na `v2` pro reset uložených layoutů.

## Commits

- feat: add Tools panel left of preview for adding video elements
- feat: add always-visible 1px divider line between dock panels