### PR TITLE
Udelej, aby jednotlive tracky sli v timeline presunovat i do jinych radku... ted se daji jen cele radky presouvat... ale

### DIFF
--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -69,6 +69,8 @@ export default function Editor() {
     splitClip,
     findClip,
     reorderTrack,
+    moveClipToTrack,
+    moveClipToNewTrack,
   } = projectHook;
 
   const [assets, setAssets] = useState<Asset[]>([]);
@@ -667,6 +669,8 @@ export default function Editor() {
             const clipId = addEffectTrack(effectType, start, dur, parentTrackId);
             setSelectedClipId(clipId);
           }}
+          onMoveClipToTrack={(clipId, toTrackId, start, end) => moveClipToTrack(clipId, toTrackId, start, end)}
+          onMoveClipToNewTrack={(clipId, newTrackType, start, end) => moveClipToNewTrack(clipId, newTrackType, start, end)}
         />
       </div>
     ),


### PR DESCRIPTION
## Summary

Implementace je hotová. Zde je shrnutí toho, co bylo změněno:

**Co bylo implementováno:**

1. **`useProject.ts`** — přidány dvě nové funkce: `moveClipToTrack` (atomicky přesune clip mezi existujícími trasami) a `moveClipToNewTrack` (vytvoří novou trasu správného typu a přesune do ní clip).

2. **`Timeline.tsx`** — přidán `clipDragStateRef`, který sleduje aktuální cílovou trasu při tažení clipu. Při pohybu kurzoru přes jiný řádek se clip okamžitě přesune do nové trasy v reálném čase. Pokud kurzor skončí pod všemi trasami, zobrazí se zóna `+ NEW` a při uvolnění myši se vytvoří nová trasa. Žádné nové trasy se nevkládají mezi existující řádky — clip prostě přeskočí do nejbližšího řádku.

3. **`Editor.tsx`** — nové callbacky `onMoveClipToTrack` a `onMoveClipToNewTrack` propojeny s Timeline komponentou.

## Commits

- feat: enable dragging individual clips between timeline track rows
- fix: make cartoon preview effect robust and always visible