### PR TITLE
Udelej aby posuvniky v efekt, napriklad v color grade... aby meli vzdycky takovy trochu magnet k defaultni hodnote.... t

### DIFF
--- a/apps/web/src/components/Inspector.tsx
+++ b/apps/web/src/components/Inspector.tsx
@@ -11,6 +11,7 @@ import type {
   WordTimestamp,
 } from '@video-editor/shared';
 import { formatTime } from '@/lib/utils';
+import { SnapSlider } from './effects/SnapSlider';
 
 interface Props {
   project: Project | null;
@@ -372,24 +373,24 @@ export default function Inspector({
                   <>
                     <Row label="X Axis">
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="range" min={0} max={1} step={0.05} value={cfg.smoothingX ?? 0.7} style={{ width: '100%' }}
-                          onChange={(e) => update({ smoothingX: parseFloat(e.target.value), stabilizationStatus: 'pending' })}
+                        <SnapSlider min={0} max={1} step={0.05} value={cfg.smoothingX ?? 0.7} defaultValue={0.7}
+                          onChange={(v) => update({ smoothingX: v, stabilizationStatus: 'pending' })}
                         />
                         <span style={{ fontSize: 12, color: 'var(--text-muted)', width: 32, flexShrink: 0 }}>{Math.round((cfg.smoothingX ?? 0.7) * 100)}%</span>
                       </div>
                     </Row>
                     <Row label="Y Axis">
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="range" min={0} max={1} step={0.05} value={cfg.smoothingY ?? 0.7} style={{ width: '100%' }}
-                          onChange={(e) => update({ smoothingY: parseFloat(e.target.value), stabilizationStatus: 'pending' })}
+                        <SnapSlider min={0} max={1} step={0.05} value={cfg.smoothingY ?? 0.7} defaultValue={0.7}
+                          onChange={(v) => update({ smoothingY: v, stabilizationStatus: 'pending' })}
                         />
                         <span style={{ fontSize: 12, color: 'var(--text-muted)', width: 32, flexShrink: 0 }}>{Math.round((cfg.smoothingY ?? 0.7) * 100)}%</span>
                       </div>
                     </Row>
                     <Row label="Z Zoom">
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="range" min={0} max={1} step={0.05} value={cfg.smoothingZ ?? 0.0} style={{ width: '100%' }}
-                          onChange={(e) => update({ smoothingZ: parseFloat(e.target.value), stabilizationStatus: 'pending' })}
+                        <SnapSlider min={0} max={1} step={0.05} value={cfg.smoothingZ ?? 0.0} defaultValue={0.0}
+                          onChange={(v) => update({ smoothingZ: v, stabilizationStatus: 'pending' })}
                         />
                         <span style={{ fontSize: 12, color: 'var(--text-muted)', width: 32, flexShrink: 0 }}>{Math.round((cfg.smoothingZ ?? 0) * 100)}%</span>
                       </div>
@@ -423,24 +424,24 @@ export default function Inspector({
                   <>
                     <Row label="Edges">
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="range" min={0} max={1} step={0.05} value={cfg.edgeStrength ?? 0.6} style={{ width: '100%' }}
-                          onChange={(e) => update({ edgeStrength: parseFloat(e.target.value) })}
+                        <SnapSlider min={0} max={1} step={0.05} value={cfg.edgeStrength ?? 0.6} defaultValue={0.6}
+                          onChange={(v) => update({ edgeStrength: v })}
                         />
                         <span style={{ fontSize: 12, color: 'var(--text-muted)', width: 32, flexShrink: 0 }}>{Math.round((cfg.edgeStrength ?? 0.6) * 100)}%</span>
                       </div>
                     </Row>
                     <Row label="Flatten">
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="range" min={0} max={1} step={0.05} value={cfg.colorSimplification ?? 0.5} style={{ width: '100%' }}
-                          onChange={(e) => update({ colorSimplification: parseFloat(e.target.value) })}
+                        <SnapSlider min={0} max={1} step={0.05} value={cfg.colorSimplification ?? 0.5} defaultValue={0.5}
+                          onChange={(v) => update({ colorSimplification: v })}
                         />
                         <span style={{ fontSize: 12, color: 'var(--text-muted)', width: 32, flexShrink: 0 }}>{Math.round((cfg.colorSimplification ?? 0.5) * 100)}%</span>
                       </div>
                     </Row>
                     <Row label="Saturation">
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="range" min={0} max={2} step={0.05} value={cfg.saturation ?? 1.5} style={{ width: '100%' }}
-                          onChange={(e) => update({ saturation: parseFloat(e.target.value) })}
+                        <SnapSlider min={0} max={2} step={0.05} value={cfg.saturation ?? 1.5} defaultValue={1.5}
+                          onChange={(v) => update({ saturation: v })}
                         />
                         <span style={{ fontSize: 12, color: 'var(--text-muted)', width: 36, flexShrink: 0 }}>{(cfg.saturation ?? 1.5).toFixed(1)}×</span>
                       </div>
@@ -452,48 +453,48 @@ export default function Inspector({
                   <>
                     <Row label="Contrast">
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="range" min={0} max={2} step={0.05} value={cfg.contrast ?? 1} style={{ width: '100%' }}
-                          onChange={(e) => update({ contrast: parseFloat(e.target.value) })}
+                        <SnapSlider min={0} max={2} step={0.05} value={cfg.contrast ?? 1} defaultValue={1}
+                          onChange={(v) => update({ contrast: v })}
                         />
                         <span style={{ fontSize: 12, color: 'var(--text-muted)', width: 36, flexShrink: 0 }}>{(cfg.contrast ?? 1).toFixed(2)}</span>
                       </div>
                     </Row>
                     <Row label="Brightness">
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="range" min={0} max={2} step={0.05} value={cfg.brightness ?? 1} style={{ width: '100%' }}
-                          onChange={(e) => update({ brightness: parseFloat(e.target.value) })}
+                        <SnapSlider min={0} max={2} step={0.05} value={cfg.brightness ?? 1} defaultValue={1}
+                          onChange={(v) => update({ brightness: v })}
                         />
                         <span style={{ fontSize: 12, color: 'var(--text-muted)', width: 36, flexShrink: 0 }}>{(cfg.brightness ?? 1).toFixed(2)}</span>
                       </div>
                     </Row>
                     <Row label="Saturation">
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="range" min={0} max={2} step={0.05} value={cfg.colorSaturation ?? 1} style={{ width: '100%' }}
-                          onChange={(e) => update({ colorSaturation: parseFloat(e.target.value) })}
+                        <SnapSlider min={0} max={2} step={0.05} value={cfg.colorSaturation ?? 1} defaultValue={1}
+                          onChange={(v) => update({ colorSaturation: v })}
                         />
                         <span style={{ fontSize: 12, color: 'var(--text-muted)', width: 36, flexShrink: 0 }}>{(cfg.colorSaturation ?? 1).toFixed(2)}</span>
                       </div>
                     </Row>
                     <Row label="Hue">
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="range" min={-180} max={180} step={1} value={cfg.hue ?? 0} style={{ width: '100%' }}
-                          onChange={(e) => update({ hue: parseFloat(e.target.value) })}
+                        <SnapSlider min={-180} max={180} step={1} value={cfg.hue ?? 0} defaultValue={0}
+                          onChange={(v) => update({ hue: v })}
                         />
                         <span style={{ fontSize: 12, color: 'var(--text-muted)', width: 36, flexShrink: 0 }}>{(cfg.hue ?? 0).toFixed(0)}°</span>
                       </div>
                     </Row>
                     <Row label="Shadows">
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="range" min={-1} max={1} step={0.05} value={cfg.shadows ?? 0} style={{ width: '100%' }}
-                          onChange={(e) => update({ shadows: parseFloat(e.target.value) })}
+                        <SnapSlider min={-1} max={1} step={0.05} value={cfg.shadows ?? 0} defaultValue={0}
+                          onChange={(v) => update({ shadows: v })}
                         />
                         <span style={{ fontSize: 12, color: 'var(--text-muted)', width: 36, flexShrink: 0 }}>{(cfg.shadows ?? 0) >= 0 ? '+' : ''}{(cfg.shadows ?? 0).toFixed(2)}</span>
                       </div>
                     </Row>
                     <Row label="Highlights">
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="range" min={-1} max={1} step={0.05} value={cfg.highlights ?? 0} style={{ width: '100%' }}
-                          onChange={(e) => update({ highlights: parseFloat(e.target.value) })}
+                        <SnapSlider min={-1} max={1} step={0.05} value={cfg.highlights ?? 0} defaultValue={0}
+                          onChange={(v) => update({ highlights: v })}
                         />
                         <span style={{ fontSize: 12, color: 'var(--text-muted)', width: 36, flexShrink: 0 }}>{(cfg.highlights ?? 0) >= 0 ? '+' : ''}{(cfg.highlights ?? 0).toFixed(2)}</span>
                       </div>

--- a/apps/web/src/components/effects/CartoonEffectPanel.tsx
+++ b/apps/web/src/components/effects/CartoonEffectPanel.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { SnapSlider } from './SnapSlider';
+
 interface CartoonEffect {
   type: 'cartoon';
   enabled: boolean;
@@ -29,23 +31,20 @@ export function CartoonEffectPanel({ clipId, effect, onRemove, onUpdate }: Omit<
       </label>
       {(
         [
-          { key: 'edgeStrength' as const, label: 'Edges', min: 0, max: 1, format: (v: number) => `${Math.round(v * 100)}%` },
-          { key: 'colorSimplification' as const, label: 'Flatten', min: 0, max: 1, format: (v: number) => `${Math.round(v * 100)}%` },
-          { key: 'saturation' as const, label: 'Saturation', min: 0, max: 2, format: (v: number) => `${v.toFixed(1)}×` },
+          { key: 'edgeStrength' as const, label: 'Edges', min: 0, max: 1, defaultValue: 0.6, format: (v: number) => `${Math.round(v * 100)}%` },
+          { key: 'colorSimplification' as const, label: 'Flatten', min: 0, max: 1, defaultValue: 0.5, format: (v: number) => `${Math.round(v * 100)}%` },
+          { key: 'saturation' as const, label: 'Saturation', min: 0, max: 2, defaultValue: 1.5, format: (v: number) => `${v.toFixed(1)}×` },
         ] as const
-      ).map(({ key, label, min, max, format }) => (
+      ).map(({ key, label, min, max, defaultValue, format }) => (
         <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <span style={{ fontSize: 13, color: 'rgba(15,23,42,0.45)', width: 70, flexShrink: 0 }}>{label}</span>
-          <input
-            type="range"
+          <SnapSlider
             min={min}
             max={max}
             step={0.05}
             value={effect[key]}
-            style={{ flex: 1 }}
-            onChange={(e) =>
-              onUpdate(clipId, 'cartoon', { [key]: parseFloat(e.target.value) })
-            }
+            defaultValue={defaultValue}
+            onChange={(v) => onUpdate(clipId, 'cartoon', { [key]: v })}
           />
           <span style={{ fontSize: 12, color: 'rgba(15,23,42,0.45)', width: 36, flexShrink: 0 }}>
             {format(effect[key])}

--- a/apps/web/src/components/effects/ColorGradeEffectPanel.tsx
+++ b/apps/web/src/components/effects/ColorGradeEffectPanel.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { SnapSlider } from './SnapSlider';
+
 interface ColorGradeEffect {
   type: 'colorGrade';
   enabled: boolean;
@@ -20,12 +22,12 @@ interface Props {
 }
 
 const SLIDERS = [
-  { key: 'contrast' as const,        label: 'Contrast',    min: 0,    max: 2,   step: 0.05, format: (v: number) => v.toFixed(2) },
-  { key: 'brightness' as const,      label: 'Brightness',  min: 0,    max: 2,   step: 0.05, format: (v: number) => v.toFixed(2) },
-  { key: 'colorSaturation' as const, label: 'Saturation',  min: 0,    max: 2,   step: 0.05, format: (v: number) => v.toFixed(2) },
-  { key: 'hue' as const,             label: 'Hue',         min: -180, max: 180, step: 1,    format: (v: number) => `${v.toFixed(0)}°` },
-  { key: 'shadows' as const,         label: 'Shadows',     min: -1,   max: 1,   step: 0.05, format: (v: number) => `${v >= 0 ? '+' : ''}${v.toFixed(2)}` },
-  { key: 'highlights' as const,      label: 'Highlights',  min: -1,   max: 1,   step: 0.05, format: (v: number) => `${v >= 0 ? '+' : ''}${v.toFixed(2)}` },
+  { key: 'contrast' as const,        label: 'Contrast',    min: 0,    max: 2,   step: 0.05, defaultValue: 1,  format: (v: number) => v.toFixed(2) },
+  { key: 'brightness' as const,      label: 'Brightness',  min: 0,    max: 2,   step: 0.05, defaultValue: 1,  format: (v: number) => v.toFixed(2) },
+  { key: 'colorSaturation' as const, label: 'Saturation',  min: 0,    max: 2,   step: 0.05, defaultValue: 1,  format: (v: number) => v.toFixed(2) },
+  { key: 'hue' as const,             label: 'Hue',         min: -180, max: 180, step: 1,    defaultValue: 0,  format: (v: number) => `${v.toFixed(0)}°` },
+  { key: 'shadows' as const,         label: 'Shadows',     min: -1,   max: 1,   step: 0.05, defaultValue: 0,  format: (v: number) => `${v >= 0 ? '+' : ''}${v.toFixed(2)}` },
+  { key: 'highlights' as const,      label: 'Highlights',  min: -1,   max: 1,   step: 0.05, defaultValue: 0,  format: (v: number) => `${v >= 0 ? '+' : ''}${v.toFixed(2)}` },
 ] as const;
 
 export function ColorGradeEffectPanel({ clipId, effect, onRemove, onUpdate }: Omit<Props, 'onAdd'>) {
@@ -39,19 +41,16 @@ export function ColorGradeEffectPanel({ clipId, effect, onRemove, onUpdate }: Om
         />
         Enabled
       </label>
-      {SLIDERS.map(({ key, label, min, max, step, format }) => (
+      {SLIDERS.map(({ key, label, min, max, step, defaultValue, format }) => (
         <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <span style={{ fontSize: 13, color: 'rgba(15,23,42,0.45)', width: 70, flexShrink: 0 }}>{label}</span>
-          <input
-            type="range"
+          <SnapSlider
             min={min}
             max={max}
             step={step}
             value={effect[key]}
-            style={{ flex: 1 }}
-            onChange={(e) =>
-              onUpdate(clipId, 'colorGrade', { [key]: parseFloat(e.target.value) })
-            }
+            defaultValue={defaultValue}
+            onChange={(v) => onUpdate(clipId, 'colorGrade', { [key]: v })}
           />
           <span style={{ fontSize: 12, color: 'rgba(15,23,42,0.45)', width: 40, flexShrink: 0 }}>
             {format(effect[key])}

--- a/apps/web/src/components/effects/HeadStabilizationEffectPanel.tsx
+++ b/apps/web/src/components/effects/HeadStabilizationEffectPanel.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { SnapSlider } from './SnapSlider';
+
 interface HeadStabilizationEffect {
   type: 'headStabilization';
   enabled: boolean;
@@ -31,26 +33,20 @@ export function HeadStabilizationEffectPanel({ clipId, effect, onRemove, onUpdat
       </label>
       {(
         [
-          { key: 'smoothingX' as const, label: 'X Axis' },
-          { key: 'smoothingY' as const, label: 'Y Axis' },
-          { key: 'smoothingZ' as const, label: 'Z Zoom' },
+          { key: 'smoothingX' as const, label: 'X Axis', defaultValue: 0.7 },
+          { key: 'smoothingY' as const, label: 'Y Axis', defaultValue: 0.7 },
+          { key: 'smoothingZ' as const, label: 'Z Zoom', defaultValue: 0.0 },
         ] as const
-      ).map(({ key, label }) => (
+      ).map(({ key, label, defaultValue }) => (
         <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <span style={{ fontSize: 13, color: 'rgba(15,23,42,0.45)', width: 52, flexShrink: 0 }}>{label}</span>
-          <input
-            type="range"
+          <SnapSlider
             min={0}
             max={1}
             step={0.05}
             value={effect[key]}
-            style={{ flex: 1 }}
-            onChange={(e) =>
-              onUpdate(clipId, 'headStabilization', {
-                [key]: parseFloat(e.target.value),
-                status: 'pending',
-              })
-            }
+            defaultValue={defaultValue}
+            onChange={(v) => onUpdate(clipId, 'headStabilization', { [key]: v, status: 'pending' })}
           />
           <span style={{ fontSize: 12, color: 'rgba(15,23,42,0.45)', width: 32, flexShrink: 0 }}>
             {Math.round(effect[key] * 100)}%

--- a/apps/web/src/components/effects/SnapSlider.tsx
+++ b/apps/web/src/components/effects/SnapSlider.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useCallback } from 'react';
+
+interface SnapSliderProps {
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  defaultValue: number;
+  onChange: (value: number) => void;
+  style?: React.CSSProperties;
+  /**
+   * Snap zone as a fraction of the total range.
+   * Default: 0.04 (4% of range on each side of defaultValue triggers snap)
+   */
+  snapThreshold?: number;
+}
+
+/**
+ * Range slider that magnetically snaps to the default value when dragged nearby.
+ * Shows a small tick mark at the default position so users know where it is.
+ */
+export function SnapSlider({
+  min,
+  max,
+  step,
+  value,
+  defaultValue,
+  onChange,
+  style,
+  snapThreshold = 0.04,
+}: SnapSliderProps) {
+  const range = max - min;
+  const threshold = range * snapThreshold;
+  const isAtDefault = value === defaultValue;
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = parseFloat(e.target.value);
+      const snapped = Math.abs(raw - defaultValue) <= threshold ? defaultValue : raw;
+      onChange(snapped);
+    },
+    [defaultValue, threshold, onChange],
+  );
+
+  // Percentage position of the default value along the track.
+  // The browser renders thumb centers at 8px from each edge (for ~16px thumb),
+  // so we apply a small correction to keep the tick visually aligned.
+  const pct = ((defaultValue - min) / range) * 100;
+  // Correction: thumb offset compensation (approximated for 16px thumb)
+  const tickLeft = `calc(${pct}% + (50 - ${pct}) * 0.12px)`;
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        ...style,
+      }}
+    >
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        style={{ width: '100%', margin: 0 }}
+        onChange={handleChange}
+      />
+      {/* Tick mark showing default value position */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          bottom: -1,
+          left: tickLeft,
+          transform: 'translateX(-50%)',
+          width: 2,
+          height: 4,
+          background: isAtDefault
+            ? 'rgba(13,148,136,0.85)'
+            : 'rgba(13,148,136,0.35)',
+          borderRadius: 1,
+          pointerEvents: 'none',
+          transition: 'background 0.15s ease',
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Hotovo. Přidal jsem magnetický snap efekt pro všechny slidery v efektech.

**Co bylo implementováno:**

- Nový komponent `SnapSlider` (`effects/SnapSlider.tsx`) – wrapper nad nativním `<input type="range">`, který při posunu v oblasti ±4 % rozsahu kolem výchozí hodnoty automaticky přiskočí na ni
- Malý teal tick mark přímo pod sliderem ukazuje pozici výchozí hodnoty; zesvětlí se, když je slider právě na defaultu
- Aplikováno na všechny efektové slidery: **Color Grade** (contrast, brightness, saturation, hue, shadows, highlights), **Cartoon** (edges, flatten, saturation) a **Head Stabilization** (X/Y/Z) – jak v panelech efektů, tak v `Inspector.tsx`

## Commits

- feat: add magnetic snap-to-default behavior for effect sliders
- feat(timeline): replace double-click split with right-click context menu