### PR TITLE
HeadStab effect nefunguje... Pri spoustine process: to pise Head stabilization failed: Process exited with code 1

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -63,6 +63,10 @@ RUN pip3 install --no-cache-dir --break-system-packages --only-binary=:all: libr
 RUN pip3 install --no-cache-dir --break-system-packages rembg onnxruntime pillow \
     || pip3 install --no-cache-dir rembg onnxruntime pillow
 
+# Install head stabilization dependencies (opencv for face detection)
+RUN pip3 install --no-cache-dir --break-system-packages --only-binary=:all: opencv-python-headless \
+    || pip3 install --no-cache-dir --only-binary=:all: opencv-python-headless
+
 # Optional: Whisper for lyrics alignment (comment in to enable, adds ~1.5GB)
 # RUN pip3 install --no-cache-dir --break-system-packages openai-whisper \
 #     || pip3 install --no-cache-dir openai-whisper

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ torchaudio>=2.0.0
 rembg>=2.0.50
 onnxruntime>=1.16.0
 pillow>=9.0.0
+# For head stabilization effect (face detection via Haar cascade)
+opencv-python-headless>=4.8.0

--- a/scripts/head_stabilize.py
+++ b/scripts/head_stabilize.py
@@ -170,7 +170,7 @@ def process_stabilize(input_path: str, output_path: str,
 
         os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
 
-        subprocess.run(
+        result = subprocess.run(
             [
                 "ffmpeg", "-y",
                 "-framerate", str(fps),
@@ -181,9 +181,14 @@ def process_stabilize(input_path: str, output_path: str,
                 "-pix_fmt", "yuv420p",
                 output_path,
             ],
-            check=True,
             capture_output=True,
+            text=True,
         )
+        if result.returncode != 0:
+            print(result.stdout, file=sys.stderr)
+            print(result.stderr, file=sys.stderr)
+            print(f"ERROR: ffmpeg exited with code {result.returncode}", file=sys.stderr)
+            sys.exit(result.returncode)
 
     print(f"[head_stabilize] Done: {output_path}")
 


### PR DESCRIPTION
## Summary

**Root cause:** `opencv-python-headless` was never installed in the Docker image. The `head_stabilize.py` script imports `cv2` (OpenCV) for face detection, but the Dockerfile only installed `librosa`, `soundfile`, `numpy`, `rembg`, `onnxruntime`, and `pillow`.

**What was fixed:**
1. **`requirements.txt`** — added `opencv-python-headless>=4.8.0`
2. **`apps/api/Dockerfile`** — added a pip install step for `opencv-python-headless` (using `--only-binary=:all:` for fast binary install)
3. **`scripts/head_stabilize.py`** — replaced `check=True, capture_output=True` with explicit error handling that forwards ffmpeg stderr to job logs, making future failures much easier to diagnose

After rebuilding the Docker image (`docker compose build api && docker compose up -d`), the HeadStab effect should work correctly.

## Commits

- fix: add opencv-python-headless dependency for head stabilization