### PR TITLE
Proc ted u cutout effektu vidim status ze neni processed a tlacitko process... ale pritom u video vlevo v media, vidim c

### DIFF
--- a/apps/web/src/components/Inspector.tsx
+++ b/apps/web/src/components/Inspector.tsx
@@ -183,15 +183,16 @@ export default function Inspector({
     }
 
     // Fallback: parentTrackId missing or points to deleted track — scan all video tracks
-    // for any clip overlapping the effect clip in the timeline.
+    // for a clip overlapping the effect clip, falling back to clips[0] of each track.
     if (!selectedAsset) {
       const videoTracks = project.tracks.filter((t) => t.type === 'video');
       for (const vt of videoTracks) {
         const overlapping = vt.clips.find(
           (c) => c.timelineEnd > selectedClip!.timelineStart && c.timelineStart < selectedClip!.timelineEnd
         );
-        if (overlapping) {
-          selectedAsset = assets.find((a) => a.id === overlapping.assetId);
+        const sourceClip = overlapping ?? vt.clips[0];
+        if (sourceClip) {
+          selectedAsset = assets.find((a) => a.id === sourceClip.assetId);
           if (selectedAsset) break;
         }
       }


### PR DESCRIPTION
## Summary

Opraveno. Problém byl v sekundárním fallbacku v `Inspector.tsx` — když neměl effect track nastavený `parentTrackId` (smazaná nebo chybějící vazba) **a zároveň** se effect clip časově nepřekrýval s žádným video clipem, `selectedAsset` zůstal `undefined` → Inspector zobrazil "Not processed" + "Process" tlačítko, zatímco MediaBin správně ukazoval "Cutout ready" (z `asset.maskPath`).

**Fix:** sekundární fallback teď zrcadlí logiku primárního — pokud v daném video tracku není žádný překrývající se clip, použije `vt.clips[0]` jako záchrannou variantu, stejně jako to dělá primární větev s `parentTrackId`. Přidán také nový test pro scénář "žádný overlap + žádný parentTrackId". Všech 6 testů prochází.

## Commits

- fix: resolve cutout status when effect clip has no time overlap and no parentTrackId
- fix: unify cutout status labels and improve asset resolution fallback