### PR TITLE
Proc ted u cutout effektu vidim status ze neni processed a tlacitko process... ale pritom u video vlevo v media, vidim c

### DIFF
--- a/apps/web/src/__tests__/InspectorCutoutStatus.test.tsx
+++ b/apps/web/src/__tests__/InspectorCutoutStatus.test.tsx
@@ -121,8 +121,9 @@ describe('Inspector – cutout status via parent track resolution', () => {
     );
 
     // The cutout status should say "Cutout ready" (green), not "Not processed"
-    expect(screen.getByText('Cutout ready')).toBeDefined();
+    expect(screen.getByText('✓ Cutout ready')).toBeDefined();
     expect(screen.queryByText('Not processed')).toBeNull();
+    expect(screen.queryByText('Cutout ready')).toBeNull(); // old label without checkmark
   });
 
   it('shows "Not processed" when the parent asset has no maskPath', () => {
@@ -372,8 +373,9 @@ describe('Inspector – cutout status via parent track resolution', () => {
     );
 
     // Fallback resolution should still find the asset and show "Cutout ready"
-    expect(screen.getByText('Cutout ready')).toBeDefined();
+    expect(screen.getByText('✓ Cutout ready')).toBeDefined();
     expect(screen.queryByText('Not processed')).toBeNull();
+    expect(screen.queryByText('Cutout ready')).toBeNull(); // old label without checkmark
   });
 
   it('shows "Cutout ready" via clips[0] fallback when no parentTrackId and no time overlap', () => {
@@ -437,7 +439,113 @@ describe('Inspector – cutout status via parent track resolution', () => {
     );
 
     // clips[0] fallback should resolve to asset_1 which has maskPath → "Cutout ready"
-    expect(screen.getByText('Cutout ready')).toBeDefined();
+    expect(screen.getByText('✓ Cutout ready')).toBeDefined();
     expect(screen.queryByText('Not processed')).toBeNull();
+    expect(screen.queryByText('Cutout ready')).toBeNull(); // old label without checkmark
+  });
+
+  it('shows the resolved video asset name in the Video row', () => {
+    const asset = makeAsset({ id: 'asset_1', name: 'my-clip.mp4', maskPath: 'masks/asset_1.mp4' });
+
+    const videoTrack = {
+      id: 'track_video',
+      type: 'video' as const,
+      name: 'Video 1',
+      muted: false,
+      clips: [
+        {
+          id: 'clip_video',
+          assetId: 'asset_1',
+          trackId: 'track_video',
+          timelineStart: 0,
+          timelineEnd: 10,
+          sourceStart: 0,
+          sourceEnd: 10,
+        },
+      ],
+    };
+
+    const effectClipId = 'clip_effect_video_row';
+    const effectTrack = {
+      id: 'track_effect',
+      type: 'effect' as const,
+      effectType: 'cutout' as const,
+      parentTrackId: 'track_video',
+      name: 'Cutout 1',
+      muted: false,
+      clips: [
+        {
+          id: effectClipId,
+          assetId: '',
+          trackId: 'track_effect',
+          timelineStart: 0,
+          timelineEnd: 10,
+          sourceStart: 0,
+          sourceEnd: 10,
+          effectConfig: {
+            effectType: 'cutout' as const,
+            enabled: true,
+            background: { type: 'solid' as const, color: '#000000' },
+          },
+        },
+      ],
+    };
+
+    const project = makeProject({ tracks: [effectTrack, videoTrack] });
+
+    render(
+      <Inspector
+        {...baseProps}
+        project={project}
+        selectedClipId={effectClipId}
+        assets={[asset]}
+      />,
+    );
+
+    // The "Video" row should show the resolved asset name
+    expect(screen.getByText('my-clip.mp4')).toBeDefined();
+  });
+
+  it('shows "No video found" in the Video row when asset cannot be resolved', () => {
+    const effectClipId = 'clip_effect_no_asset';
+    // Effect track with no parentTrackId and no video tracks in the project
+    const effectTrack = {
+      id: 'track_effect',
+      type: 'effect' as const,
+      effectType: 'cutout' as const,
+      parentTrackId: undefined as unknown as string,
+      name: 'Cutout 1',
+      muted: false,
+      clips: [
+        {
+          id: effectClipId,
+          assetId: '',
+          trackId: 'track_effect',
+          timelineStart: 0,
+          timelineEnd: 10,
+          sourceStart: 0,
+          sourceEnd: 10,
+          effectConfig: {
+            effectType: 'cutout' as const,
+            enabled: true,
+            background: { type: 'solid' as const, color: '#000000' },
+          },
+        },
+      ],
+    };
+
+    const project = makeProject({ tracks: [effectTrack] }); // no video tracks
+
+    render(
+      <Inspector
+        {...baseProps}
+        project={project}
+        selectedClipId={effectClipId}
+        assets={[]}
+      />,
+    );
+
+    // No asset found → show fallback text
+    expect(screen.getByText('No video found')).toBeDefined();
   });
 });

--- a/apps/web/src/components/Inspector.tsx
+++ b/apps/web/src/components/Inspector.tsx
@@ -242,6 +242,19 @@ export default function Inspector({
                 </span>
               </Row>
             )}
+            {selectedTrackType === 'effect' && (
+              <Row label="Video">
+                {selectedAsset ? (
+                  <span style={{ fontSize: 13, color: 'var(--text-secondary)', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {selectedAsset.name}
+                  </span>
+                ) : (
+                  <span style={{ fontSize: 12, color: 'var(--text-muted)', fontStyle: 'italic' }}>
+                    No video found
+                  </span>
+                )}
+              </Row>
+            )}
             <Row label="Start">{valueText(formatTime(selectedClip.timelineStart))}</Row>
             <Row label="End">{valueText(formatTime(selectedClip.timelineEnd))}</Row>
             <Row label="Duration">{valueText(formatTime(selectedClip.timelineEnd - selectedClip.timelineStart))}</Row>
@@ -401,7 +414,7 @@ export default function Inspector({
                               color: isCutoutDone ? '#4ade80' : cutoutJob?.status === 'ERROR' ? '#f87171' : cutoutJob?.status === 'CANCELLED' ? '#94a3b8' : 'var(--text-subtle)',
                               flex: 1,
                             }}>
-                              {isCutoutDone && 'Cutout ready'}
+                              {isCutoutDone && '✓ Cutout ready'}
                               {!isCutoutDone && cutoutJob?.status === 'ERROR' && 'Error – retry'}
                               {!isCutoutDone && cutoutJob?.status === 'CANCELLED' && 'Cancelled'}
                               {!isCutoutDone && (!cutoutJob || (cutoutJob.status !== 'ERROR' && cutoutJob.status !== 'CANCELLED')) && 'Not processed'}


### PR DESCRIPTION
## Summary

Hotovo. Tady jsou konkrétní změny:

**Kořen problému:** MediaBin zobrazoval `✓ Cutout ready` pro jakékoli video, které mělo hotový cutout. Inspector ale zobrazoval status pro *konkrétní* video, ke kterému je efekt přiřazen — pokud se jednalo o jiné video (bez zpracovaného cutoutu), ukázal `Not processed`. Dvě různá videa, dvě různé informace, nula kontextu pro uživatele.

**Co bylo opraveno:**

1. **Sjednocený text:** Inspector nyní zobrazuje `✓ Cutout ready` (s fajfkou) místo `Cutout ready` — stejně jako MediaBin.

2. **Nový řádek „Video":** V sekci Effect Info přibyl řádek ukazující název zdrojového videa, ke kterému se efekt váže. Uživatel tak okamžitě vidí, pro které video je cutout status zobrazen.

3. **Fallback:** Pokud Inspector nedokáže video dohledat, zobrazí `No video found` místo tichého mlčení.

## Commits

- fix: unify cutout status display between MediaBin and Inspector