### PR TITLE
Ctrl Z nefunguje, melo by to vracet zmeny

### DIFF
--- a/apps/web/src/__tests__/useHistory.test.tsx
+++ b/apps/web/src/__tests__/useHistory.test.tsx
@@ -30,7 +30,7 @@ describe('useHistory', () => {
     expect(result.current.canRedo).toBe(false);
   });
 
-  it('canUndo becomes true after pushSnapshot', () => {
+  it('canUndo remains false after only one pushSnapshot (need 2+ states)', () => {
     vi.useFakeTimers();
     const setProject = vi.fn();
     const project = makeProject('A');
@@ -41,58 +41,52 @@ describe('useHistory', () => {
       vi.runAllTimers();
     });
 
+    // One snapshot = current state only; need at least 2 to be able to undo
+    expect(result.current.canUndo).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it('canUndo becomes true after two distinct pushSnapshots', () => {
+    vi.useFakeTimers();
+    const setProject = vi.fn();
+    const v1 = makeProject('V1');
+    const v2 = makeProject('V2');
+    const { result } = renderHook(() => useHistory(v1, setProject));
+
+    act(() => { result.current.pushSnapshot(v1); vi.runAllTimers(); });
+    act(() => { result.current.pushSnapshot(v2); vi.runAllTimers(); });
+
     expect(result.current.canUndo).toBe(true);
     vi.useRealTimers();
   });
 
-  it('undo calls setProject with previous snapshot', async () => {
+  it('undo calls setProject with the state BEFORE the last change', () => {
     vi.useFakeTimers();
     const setProject = vi.fn();
-    const projectV1 = makeProject('Version 1');
-    const projectV2 = makeProject('Version 2');
+    const v1 = makeProject('Version 1');
+    const v2 = makeProject('Version 2');
 
-    // Start with V1
     const { result, rerender } = renderHook(
       ({ project }) => useHistory(project, setProject),
-      { initialProps: { project: projectV1 } }
+      { initialProps: { project: v1 } }
     );
 
-    // Push V1 snapshot
-    act(() => { result.current.pushSnapshot(projectV1); });
+    // Simulate the real flow: push V1 (initial state), then push V2 (after change)
+    act(() => { result.current.pushSnapshot(v1); });
     act(() => { vi.runAllTimers(); });
 
-    // Switch to V2
-    rerender({ project: projectV2 });
+    rerender({ project: v2 });
+    act(() => { result.current.pushSnapshot(v2); });
+    act(() => { vi.runAllTimers(); });
 
-    // Undo should restore V1
+    // Undo should restore V1 (the state before the V2 change)
     act(() => { result.current.undo(); });
 
     expect(setProject).toHaveBeenCalledWith(expect.objectContaining({ name: 'Version 1' }));
     vi.useRealTimers();
   });
 
-  it('canRedo becomes true after undo', async () => {
-    vi.useFakeTimers();
-    const setProject = vi.fn();
-    const projectV1 = makeProject('V1');
-    const projectV2 = makeProject('V2');
-
-    const { result, rerender } = renderHook(
-      ({ project }) => useHistory(project, setProject),
-      { initialProps: { project: projectV1 } }
-    );
-
-    act(() => { result.current.pushSnapshot(projectV1); });
-    act(() => { vi.runAllTimers(); });
-    rerender({ project: projectV2 });
-
-    act(() => { result.current.undo(); });
-
-    expect(result.current.canRedo).toBe(true);
-    vi.useRealTimers();
-  });
-
-  it('redo restores the undone state', async () => {
+  it('canRedo becomes true after undo', () => {
     vi.useFakeTimers();
     const setProject = vi.fn();
     const v1 = makeProject('V1');
@@ -105,20 +99,49 @@ describe('useHistory', () => {
 
     act(() => { result.current.pushSnapshot(v1); });
     act(() => { vi.runAllTimers(); });
+
     rerender({ project: v2 });
+    act(() => { result.current.pushSnapshot(v2); });
+    act(() => { vi.runAllTimers(); });
+
+    act(() => { result.current.undo(); });
+
+    expect(result.current.canRedo).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('redo restores the undone state', () => {
+    vi.useFakeTimers();
+    const setProject = vi.fn();
+    const v1 = makeProject('V1');
+    const v2 = makeProject('V2');
+
+    const { result, rerender } = renderHook(
+      ({ project }) => useHistory(project, setProject),
+      { initialProps: { project: v1 } }
+    );
+
+    act(() => { result.current.pushSnapshot(v1); });
+    act(() => { vi.runAllTimers(); });
+
+    rerender({ project: v2 });
+    act(() => { result.current.pushSnapshot(v2); });
+    act(() => { vi.runAllTimers(); });
 
     act(() => { result.current.undo(); });
     // After undo, setProject called with V1
     expect(setProject).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'V1' }));
 
+    // Simulate project reverting to v1
+    rerender({ project: v1 });
+
     // Now redo
-    rerender({ project: v1 }); // simulate setProject effect
     act(() => { result.current.redo(); });
     expect(setProject).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'V2' }));
     vi.useRealTimers();
   });
 
-  it('canRedo becomes false after new pushSnapshot', async () => {
+  it('canRedo becomes false after new pushSnapshot', () => {
     vi.useFakeTimers();
     const setProject = vi.fn();
     const v1 = makeProject('V1');
@@ -132,11 +155,15 @@ describe('useHistory', () => {
 
     act(() => { result.current.pushSnapshot(v1); });
     act(() => { vi.runAllTimers(); });
+
     rerender({ project: v2 });
+    act(() => { result.current.pushSnapshot(v2); });
+    act(() => { vi.runAllTimers(); });
+
     act(() => { result.current.undo(); });
     expect(result.current.canRedo).toBe(true);
 
-    // Push a new snapshot - future should clear
+    // Simulate reverting to v1 and then making a new change (clears future)
     rerender({ project: v1 });
     act(() => { result.current.pushSnapshot(v3); });
     act(() => { vi.runAllTimers(); });
@@ -144,23 +171,25 @@ describe('useHistory', () => {
     vi.useRealTimers();
   });
 
-  it('does not push duplicate snapshots', async () => {
+  it('does not push duplicate snapshots', () => {
     vi.useFakeTimers();
     const setProject = vi.fn();
-    const project = makeProject('Same');
+    const v1 = makeProject('V1');
+    const v2 = makeProject('V2');
 
-    const { result } = renderHook(() => useHistory(project, setProject));
+    const { result } = renderHook(() => useHistory(v1, setProject));
 
-    act(() => { result.current.pushSnapshot(project); });
-    act(() => { vi.runAllTimers(); });
-    act(() => { result.current.pushSnapshot(project); }); // same content
-    act(() => { vi.runAllTimers(); });
+    // Push V1 twice — second push should be deduplicated
+    act(() => { result.current.pushSnapshot(v1); vi.runAllTimers(); });
+    act(() => { result.current.pushSnapshot(v1); vi.runAllTimers(); }); // duplicate
 
-    // Should only have 1 history entry (no duplicate)
+    // Push V2 — this is a real new state
+    act(() => { result.current.pushSnapshot(v2); vi.runAllTimers(); });
+
+    // past = [V1, V2] — only 2 unique entries
     expect(result.current.canUndo).toBe(true);
-    act(() => { result.current.undo(); });
-    // After one undo, no more past
-    expect(result.current.canUndo).toBe(false);
+    act(() => { result.current.undo(); }); // restore V1; past = [V1], future = [V2]
+    expect(result.current.canUndo).toBe(false); // only V1 left, nothing to undo to
     vi.useRealTimers();
   });
 
@@ -170,6 +199,20 @@ describe('useHistory', () => {
     const { result } = renderHook(() => useHistory(project, setProject));
     act(() => { result.current.undo(); });
     expect(setProject).not.toHaveBeenCalled();
+  });
+
+  it('undo does nothing when only one snapshot exists (current state only)', () => {
+    vi.useFakeTimers();
+    const setProject = vi.fn();
+    const project = makeProject('P');
+    const { result } = renderHook(() => useHistory(project, setProject));
+
+    act(() => { result.current.pushSnapshot(project); vi.runAllTimers(); });
+
+    // Only 1 snapshot = current state; no previous state to restore
+    act(() => { result.current.undo(); });
+    expect(setProject).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 
   it('redo does nothing when no future', () => {
@@ -189,7 +232,7 @@ describe('useHistory', () => {
     expect(setProject).not.toHaveBeenCalled();
   });
 
-  it('limits history to 50 entries', async () => {
+  it('limits history to 50 entries', () => {
     vi.useFakeTimers();
     const setProject = vi.fn();
     let project = makeProject('P0');
@@ -207,7 +250,7 @@ describe('useHistory', () => {
       act(() => { vi.runAllTimers(); });
     }
 
-    // Undo 50 times (history is limited to 50)
+    // Undo until canUndo is false (history is limited to 50, so at most 49 undos)
     let undoCount = 0;
     while (result.current.canUndo) {
       act(() => { result.current.undo(); });
@@ -215,6 +258,46 @@ describe('useHistory', () => {
       if (undoCount > 60) break; // safety guard
     }
     expect(undoCount).toBeLessThanOrEqual(50);
+    vi.useRealTimers();
+  });
+
+  it('multiple undo/redo cycles work correctly', () => {
+    vi.useFakeTimers();
+    const setProject = vi.fn();
+    const v1 = makeProject('V1');
+    const v2 = makeProject('V2');
+    const v3 = makeProject('V3');
+
+    const { result, rerender } = renderHook(
+      ({ project }) => useHistory(project, setProject),
+      { initialProps: { project: v1 } }
+    );
+
+    // Build history: V1 → V2 → V3
+    act(() => { result.current.pushSnapshot(v1); vi.runAllTimers(); });
+    rerender({ project: v2 });
+    act(() => { result.current.pushSnapshot(v2); vi.runAllTimers(); });
+    rerender({ project: v3 });
+    act(() => { result.current.pushSnapshot(v3); vi.runAllTimers(); });
+
+    // Undo twice: V3 → V2 → V1
+    act(() => { result.current.undo(); }); // restores V2
+    expect(setProject).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'V2' }));
+
+    rerender({ project: v2 });
+    act(() => { result.current.undo(); }); // restores V1
+    expect(setProject).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'V1' }));
+    expect(result.current.canUndo).toBe(false);
+
+    // Redo twice: V1 → V2 → V3
+    rerender({ project: v1 });
+    act(() => { result.current.redo(); }); // restores V2
+    expect(setProject).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'V2' }));
+
+    rerender({ project: v2 });
+    act(() => { result.current.redo(); }); // restores V3
+    expect(setProject).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'V3' }));
+    expect(result.current.canRedo).toBe(false);
     vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

**Root cause**: Snapshots are pushed *after* every project change, so `past` always held the current state as its last entry. When `undo()` popped that entry and restored it, it was effectively restoring the current state — a no-op. Users needed to press Ctrl+Z **twice** to undo a single action.

**Fix**: `undo()` now pops the current state into `future`, then peeks at the previous entry in `past` (requiring `past.length >= 2`) and restores that — one Ctrl+Z undoes one action. `canUndo` was also updated to reflect `past.length >= 2`. All 14 history tests pass and the build succeeds cleanly.

## Commits

- fix: correct Ctrl+Z undo — was restoring current state instead of previous