### PR TITLE
V implement dialogu... pokud task v poslednich tascich nema nazev, napis tam jeho prompt

### DIFF
--- a/apps/web/src/__tests__/FeedbackButton.test.tsx
+++ b/apps/web/src/__tests__/FeedbackButton.test.tsx
@@ -162,7 +162,18 @@ describe('FeedbackButton', () => {
       });
     });
 
-    it('shows task with fallback label when name is missing', async () => {
+    it('shows prompt as label when name is missing but prompt is present', async () => {
+      mockFetchWithTasks([{ status: 'running', id: '99', prompt: 'Vygeneruj intro video' }]);
+      render(<FeedbackButton />);
+      fireEvent.click(screen.getByRole('button', { name: /napsat návrh/i }));
+      fireEvent.click(screen.getByRole('tab', { name: /poslední tasky/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Vygeneruj intro video')).toBeDefined();
+      });
+    });
+
+    it('shows "Bez názvu" when neither name nor prompt is present', async () => {
       mockFetchWithTasks([{ status: 'running', id: '99' }]);
       render(<FeedbackButton />);
       fireEvent.click(screen.getByRole('button', { name: /napsat návrh/i }));

--- a/apps/web/src/components/FeedbackButton.tsx
+++ b/apps/web/src/components/FeedbackButton.tsx
@@ -15,6 +15,7 @@ interface Task {
   title?: string;
   message?: string;
   description?: string;
+  prompt?: string;
   createdAt?: string;
   updatedAt?: string;
   [key: string]: unknown;
@@ -56,7 +57,7 @@ function getStatusLabel(status: string) {
 }
 
 function getTaskLabel(task: Task): string {
-  return task.name ?? task.title ?? task.description ?? task.message ?? 'Bez názvu';
+  return task.name ?? task.title ?? task.description ?? task.message ?? task.prompt ?? 'Bez názvu';
 }
 
 function formatTime(dateStr?: string): string {


### PR DESCRIPTION
## Summary

In `FeedbackButton.tsx`, the `Task` interface now includes `prompt?: string` and `getTaskLabel` was updated to use `task.prompt` as a fallback before `'Bez názvu'` — so tasks without a name/title/description/message will display their prompt text instead. Tests were updated to cover both cases (task with prompt but no name shows the prompt; task with neither shows "Bez názvu"), and all 158 tests pass with a clean build.

## Commits

- feat: show task prompt in dialog when task has no name