### PR TITLE
Vide v prieview trochu zlobi... zlobi jejich transform... kdyz zvetsuji a zmensuji preview sekci, tak se i meni pozice v

### DIFF
--- a/apps/web/src/__tests__/PreviewCanvasResize.test.tsx
+++ b/apps/web/src/__tests__/PreviewCanvasResize.test.tsx
@@ -190,3 +190,71 @@ describe('Preview canvas internal resolution stability', () => {
     expect(canvas.height).toBe(720);
   });
 });
+
+// ── SVG viewBox sync tests ─────────────────────────────────────────────────────
+//
+// The SVG selection overlay must carry a viewBox that maps its user coordinate
+// space to the canvas INTERNAL resolution (canvas.width × canvas.height).
+// Without it the SVG user units equal CSS pixels, causing selection handles to
+// appear at wrong positions whenever the CSS display size differs from the
+// internal canvas size (i.e. always, since the preview panel can be resized).
+
+describe('Preview SVG selection overlay viewBox', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedROCallback = null;
+    capturedContainer = null;
+  });
+
+  it('sets SVG viewBox to match canvas internal resolution on mount', () => {
+    const project = makeProject(1920, 1080);
+    const { container } = render(<Preview {...defaultProps} project={project} />);
+    const svg = container.querySelector('svg')!;
+
+    // Canvas internal dims are 1280×720 for a 1920×1080 project
+    expect(svg.getAttribute('viewBox')).toBe('0 0 1280 720');
+  });
+
+  it('sets SVG viewBox for a vertical (9:16) project', () => {
+    const project = makeProject(1080, 1920);
+    const { container } = render(<Preview {...defaultProps} project={project} />);
+    const svg = container.querySelector('svg')!;
+
+    // Canvas internal dims are 720×1280 for a 1080×1920 project
+    expect(svg.getAttribute('viewBox')).toBe('0 0 720 1280');
+  });
+
+  it('SVG viewBox stays correct after container resize', () => {
+    const project = makeProject(1920, 1080);
+    const { container } = render(<Preview {...defaultProps} project={project} />);
+    const canvas = container.querySelector('canvas')!;
+    const svg = container.querySelector('svg')!;
+
+    const internalW = canvas.width;
+    const internalH = canvas.height;
+
+    // Simulate multiple panel resizes — CSS dims change, internal must not
+    simulateContainerResize(600, 400);
+    simulateContainerResize(300, 200);
+    simulateContainerResize(1920, 1080);
+
+    expect(canvas.width).toBe(internalW);
+    expect(canvas.height).toBe(internalH);
+    expect(svg.getAttribute('viewBox')).toBe(`0 0 ${internalW} ${internalH}`);
+  });
+
+  it('updates SVG viewBox when project output resolution changes', () => {
+    const project1080p = makeProject(1920, 1080);
+    const project720p  = makeProject(1280, 720);
+
+    const { container, rerender } = render(<Preview {...defaultProps} project={project1080p} />);
+    const svg = container.querySelector('svg')!;
+
+    expect(svg.getAttribute('viewBox')).toBe('0 0 1280 720');
+
+    rerender(<Preview {...defaultProps} project={project720p} />);
+
+    // 1280×720 is ≤ 1280 on longest axis → canvas stays 1280×720
+    expect(svg.getAttribute('viewBox')).toBe('0 0 1280 720');
+  });
+});

--- a/apps/web/src/components/Preview.tsx
+++ b/apps/web/src/components/Preview.tsx
@@ -857,6 +857,9 @@ export default function Preview({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const selectionSvgRef = useRef<SVGSVGElement>(null);
+  // Tracks canvas CSS display dimensions so we can convert internal canvas
+  // coordinates → CSS pixels for DOM overlays (e.g. inline textarea editor).
+  const canvasCssDimsRef = useRef({ w: 0, h: 0 });
 
   // ── Viewport zoom / pan ───────────────────────────────────────────────────
   const [viewZoom, setViewZoom] = useState(1);
@@ -1311,6 +1314,14 @@ export default function Preview({
       drawFrame();
     }
 
+    // Keep the SVG selection overlay's coordinate space in sync with the canvas
+    // internal resolution. Without a viewBox the SVG user units would map 1:1 to
+    // CSS pixels (matching canvas.style.width/height), causing handles to appear
+    // at wrong positions when the CSS display size differs from the internal size.
+    if (selectionSvgRef.current) {
+      selectionSvgRef.current.setAttribute('viewBox', `0 0 ${canvas.width} ${canvas.height}`);
+    }
+
     const aspect = outW / outH;
 
     const ro = new ResizeObserver(() => {
@@ -1326,9 +1337,14 @@ export default function Preview({
         cssW = cssH * aspect;
       }
 
+      const roundedW = Math.round(cssW);
+      const roundedH = Math.round(cssH);
       // Update only the CSS display size — internal canvas resolution stays fixed
-      canvas.style.width = `${Math.round(cssW)}px`;
-      canvas.style.height = `${Math.round(cssH)}px`;
+      canvas.style.width = `${roundedW}px`;
+      canvas.style.height = `${roundedH}px`;
+      // Track CSS dims so DOM overlays (textarea, etc.) can convert internal
+      // canvas coordinates to CSS pixels using the ratio cssW / canvas.width.
+      canvasCssDimsRef.current = { w: roundedW, h: roundedH };
     });
     ro.observe(container);
     return () => ro.disconnect();
@@ -1926,7 +1942,18 @@ export default function Preview({
           const clip = project.tracks.flatMap((t) => t.clips).find((c) => c.id === editingState.clipId);
           if (!clip) return null;
           const { canvasCX, canvasCY, fontSize, style } = editingState;
-          const textWidth = Math.max(200, fontSize * 12);
+          // Convert internal canvas coordinates → CSS pixels so the textarea
+          // appears at the correct position regardless of preview section size.
+          // canvasCX/canvasCY are in canvas internal space (0..canvas.width/height);
+          // CSS positions are relative to the zoom wrapper sized to canvas CSS dims.
+          const canvas = canvasRef.current;
+          const cssDims = canvasCssDimsRef.current;
+          const internalW = canvas?.width ?? cssDims.w;
+          const cssRatio = internalW > 0 && cssDims.w > 0 ? cssDims.w / internalW : 1;
+          const cssFontSize = Math.round(fontSize * cssRatio);
+          const textWidth = Math.max(200, cssFontSize * 12);
+          const cssLeft = canvasCX * cssRatio - textWidth / 2;
+          const cssTop = canvasCY * cssRatio - cssFontSize * 1.5;
           return (
             <textarea
               key={editingState.clipId}
@@ -1946,15 +1973,15 @@ export default function Preview({
               }}
               style={{
                 position: 'absolute',
-                left: canvasCX - textWidth / 2,
-                top: canvasCY - fontSize * 1.5,
+                left: cssLeft,
+                top: cssTop,
                 width: textWidth,
-                minHeight: fontSize * 3,
+                minHeight: cssFontSize * 3,
                 background: 'rgba(0,0,0,0.55)',
                 border: '2px solid rgba(255,255,255,0.85)',
                 borderRadius: 4,
                 color: style.color,
-                fontSize: fontSize,
+                fontSize: cssFontSize,
                 fontFamily: style.fontFamily,
                 fontWeight: style.bold ? 'bold' : 'normal',
                 fontStyle: style.italic ? 'italic' : 'normal',


### PR DESCRIPTION
## Summary

**Root cause and fix:**

The SVG selection overlay (handles/dashed border around selected clip) had no `viewBox` attribute — so its coordinate system was in CSS pixels matching the canvas CSS display size (e.g. 800px), while all bounds were computed in canvas *internal* pixel space (fixed at up to 1280px). This made handles appear at wrong positions whenever the preview panel was resized.

**Fix applied in `Preview.tsx`:**
1. **SVG viewBox** — after setting the canvas internal resolution, `viewBox="0 0 {canvas.width} {canvas.height}"` is set on the SVG element so its coordinate space matches internal canvas pixels regardless of panel size or zoom.
2. **Inline text textarea** — `canvasCX/canvasCY/fontSize` were being used directly as CSS pixels but they're in internal space; now converted via `cssRatio = cssWidth / internalWidth` before positioning the textarea.

4 new tests added to `PreviewCanvasResize.test.tsx` covering all SVG viewBox scenarios; all 21 tests pass.

## Commits

- fix: stabilize video clip position regardless of preview section size or zoom