### PR TITLE
Video elementy v preview sekci meni svoji pozici, kdyz zmensuju tu preview sekci... oprav

### DIFF
--- a/apps/web/src/__tests__/PreviewCanvasResize.test.tsx
+++ b/apps/web/src/__tests__/PreviewCanvasResize.test.tsx
@@ -2,15 +2,17 @@
  * PreviewCanvasResize.test.tsx
  *
  * Tests that the Preview canvas maintains a completely stable rendering
- * regardless of panel/window size. After the stability fix:
+ * regardless of panel/window size:
  *
  *  - Canvas INTERNAL resolution is fixed (derived from outputResolution,
  *    capped at 1280 px on the longest axis).
  *  - Canvas CSS dimensions are also fixed to the INTERNAL resolution.
  *    Visual scaling is performed exclusively via the viewZoom CSS transform
  *    on the zoom-wrapper div — the canvas element's layout size never changes.
- *  - Panel / window resizing therefore has ZERO effect on canvas dimensions
- *    (neither internal nor CSS), so video elements never shift or shrink.
+ *  - Panel / window resizing has ZERO effect on canvas dimensions
+ *    (neither internal nor CSS). Only viewZoom is adjusted to keep the canvas
+ *    filling the panel in "fit" mode (the default), which prevents video
+ *    elements from appearing to shift when the preview section is resized.
  *  - The SVG selection-overlay viewBox always matches the internal resolution
  *    so handles remain correctly positioned at all zoom levels.
  */
@@ -47,15 +49,32 @@ HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue({
 }) as unknown as typeof HTMLCanvasElement.prototype.getContext;
 
 // ── ResizeObserver stub ────────────────────────────────────────────────────────
-// The Preview component no longer uses ResizeObserver to set canvas CSS dims
-// (it was removed in the stability fix). We still provide a no-op stub so the
-// global is defined in the test environment.
-class NoopResizeObserver {
-  observe() {}
-  disconnect() {}
-  unobserve() {}
+// The Preview component uses a ResizeObserver to auto-fit zoom when the panel
+// is resized (in "fit" mode). Canvas CSS dimensions are never changed by it —
+// only viewZoom is updated via the zoom CSS transform.
+//
+// We provide a controllable stub so tests can:
+//  1. Keep the default no-op behaviour (canvas stability tests)
+//  2. Manually fire resize callbacks to test the auto-fit zoom logic
+type ResizeCallback = (entries: ResizeObserverEntry[]) => void;
+const resizeCallbacks = new Map<Element, ResizeCallback>();
+
+class ControllableResizeObserver {
+  private cb: ResizeCallback;
+  constructor(cb: ResizeCallback) { this.cb = cb; }
+  observe(el: Element) { resizeCallbacks.set(el, this.cb); }
+  unobserve(el: Element) { resizeCallbacks.delete(el); }
+  disconnect() { resizeCallbacks.clear(); }
 }
-globalThis.ResizeObserver = NoopResizeObserver as unknown as typeof ResizeObserver;
+globalThis.ResizeObserver = ControllableResizeObserver as unknown as typeof ResizeObserver;
+
+/** Fire a resize callback for `el` with the given clientWidth/clientHeight. */
+function fireResize(el: Element, clientWidth: number, clientHeight: number) {
+  Object.defineProperty(el, 'clientWidth',  { value: clientWidth,  configurable: true });
+  Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+  const cb = resizeCallbacks.get(el);
+  if (cb) cb([{ target: el } as ResizeObserverEntry]);
+}
 
 // ── Test data ─────────────────────────────────────────────────────────────────
 
@@ -290,5 +309,72 @@ describe('Preview SVG selection overlay viewBox', () => {
 
     // 1280×720 is ≤ 1280 on longest axis → canvas stays 1280×720
     expect(svg.getAttribute('viewBox')).toBe('0 0 1280 720');
+  });
+});
+
+// ── Tests: auto-fit zoom on panel resize ──────────────────────────────────────
+//
+// The ResizeObserver detects container size changes and, when in "fit" mode,
+// recomputes viewZoom so the canvas always fills the available panel space.
+// This prevents video elements from appearing to shift when the panel is resized.
+//
+// Canvas CSS dimensions are NEVER changed — only the zoom CSS transform changes.
+
+describe('Preview auto-fit zoom on panel resize', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resizeCallbacks.clear();
+  });
+
+  it('canvas CSS dimensions do NOT change when container is resized', () => {
+    const project = makeProject(1920, 1080);
+    const { container } = render(<Preview {...defaultProps} project={project} />);
+    const canvas = container.querySelector('canvas')!;
+
+    const cssWBefore = canvas.style.width;
+    const cssHBefore = canvas.style.height;
+
+    // Simulate panel resize via ResizeObserver callback
+    const previewContainer = canvas.parentElement?.parentElement as HTMLElement;
+    if (previewContainer) {
+      act(() => { fireResize(previewContainer, 600, 400); });
+    }
+
+    // CSS dimensions must stay fixed at internal resolution — only zoom changes
+    expect(canvas.style.width).toBe(cssWBefore);
+    expect(canvas.style.height).toBe(cssHBefore);
+  });
+
+  it('zoom wrapper receives updated CSS transform scale when panel is resized in fit mode', () => {
+    const project = makeProject(1920, 1080);
+    const { container } = render(<Preview {...defaultProps} project={project} />);
+    const canvas = container.querySelector('canvas')!;
+    const zoomWrapper = container.querySelector('[data-testid="preview-zoom-wrapper"]') as HTMLElement;
+
+    // Simulate panel resize to a specific size
+    const previewContainer = canvas.parentElement?.parentElement as HTMLElement;
+    if (previewContainer && zoomWrapper) {
+      act(() => { fireResize(previewContainer, 640, 360); });
+      // canvas is 1280×720; container is 640×360 → fitZoom = min(640/1280, 360/720) = 0.5
+      const transform = zoomWrapper.style.transform;
+      expect(transform).toContain('scale(0.5)');
+    }
+  });
+
+  it('canvas internal resolution is unchanged after panel resize', () => {
+    const project = makeProject(1920, 1080);
+    const { container } = render(<Preview {...defaultProps} project={project} />);
+    const canvas = container.querySelector('canvas')!;
+
+    const internalW = canvas.width; // 1280
+    const internalH = canvas.height; // 720
+
+    const previewContainer = canvas.parentElement?.parentElement as HTMLElement;
+    if (previewContainer) {
+      act(() => { fireResize(previewContainer, 400, 300); });
+    }
+
+    expect(canvas.width).toBe(internalW);
+    expect(canvas.height).toBe(internalH);
   });
 });

--- a/apps/web/src/components/Preview.tsx
+++ b/apps/web/src/components/Preview.tsx
@@ -868,6 +868,10 @@ export default function Preview({
   const viewZoomRef = useRef(1);
   const viewPanRef = useRef({ x: 0, y: 0 });
   const midPanDragRef = useRef<{ startX: number; startY: number; startPanX: number; startPanY: number } | null>(null);
+  // Tracks whether the view is in "fit" mode (auto-fit on panel resize) or
+  // "manual" mode (user has zoomed/panned manually). True by default so the
+  // initial project load auto-fit propagates through panel resize as well.
+  const isFitModeRef = useRef(true);
 
   const setZoom = useCallback((z: number) => {
     viewZoomRef.current = z;
@@ -887,7 +891,9 @@ export default function Preview({
   }, []);
 
   // "Fit to window" — scale the canvas so it fills the available container space.
+  // Resets to fit mode so subsequent panel resizes continue to auto-fit.
   const resetView = useCallback(() => {
+    isFitModeRef.current = true;
     setZoom(clamp(computeFitZoom(), MIN_VIEW_ZOOM, MAX_VIEW_ZOOM));
     setPan({ x: 0, y: 0 });
   }, [computeFitZoom, setZoom, setPan]);
@@ -1351,8 +1357,10 @@ export default function Preview({
 
     // Auto-fit zoom: scale the canvas so it fills the container whenever the
     // output resolution changes (new project, first load, etc.).
+    // Reset to fit mode so subsequent panel resizes continue to auto-fit.
     if (container && container.clientWidth > 0 && container.clientHeight > 0) {
       const fitZoom = Math.min(container.clientWidth / refW, container.clientHeight / refH);
+      isFitModeRef.current = true;
       setZoom(clamp(fitZoom, MIN_VIEW_ZOOM, MAX_VIEW_ZOOM));
       setPan({ x: 0, y: 0 });
     }
@@ -1360,6 +1368,40 @@ export default function Preview({
   }, [project?.outputResolution?.w, project?.outputResolution?.h, setZoom, setPan]);
   // Note: drawFrame is intentionally omitted — drawFrameRef.current() is used
   // instead so that clip edits (which recreate drawFrame) do not reset the zoom.
+
+  // ── Panel resize → auto-refit zoom ───────────────────────────────────────
+  //
+  // When the user drags a dock split handle to resize the preview panel, a
+  // ResizeObserver detects the container dimension change and, if we are still
+  // in "fit" mode (isFitModeRef = true), recalculates the zoom so the canvas
+  // continues to fill the available space. This prevents video elements from
+  // appearing to shift position as the panel grows or shrinks.
+  //
+  // Canvas CSS dimensions and internal resolution are NEVER modified here —
+  // only the viewZoom CSS transform on the zoom wrapper is updated.
+  //
+  // "fit" mode is true by default and after a project load or resetView click.
+  // It switches to false (manual mode) when the user zooms/pans manually so
+  // that their custom zoom level is preserved across panel resizes.
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    if (!container || !canvas) return;
+
+    const observer = new ResizeObserver(() => {
+      if (!isFitModeRef.current) return;
+      const refW = canvas.width;
+      const refH = canvas.height;
+      if (!refW || !refH || !container.clientWidth || !container.clientHeight) return;
+      const fitZoom = Math.min(container.clientWidth / refW, container.clientHeight / refH);
+      setZoom(clamp(fitZoom, MIN_VIEW_ZOOM, MAX_VIEW_ZOOM));
+      setPan({ x: 0, y: 0 });
+    });
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [setZoom, setPan]);
 
   // ── Mouse interactions ────────────────────────────────────────────────────
 
@@ -1507,6 +1549,8 @@ export default function Preview({
 
     const onWheel = (e: WheelEvent) => {
       e.preventDefault();
+      // User is manually zooming — disable auto-fit on panel resize.
+      isFitModeRef.current = false;
       const rect = container.getBoundingClientRect();
       const containerCX = rect.left + rect.width / 2;
       const containerCY = rect.top + rect.height / 2;
@@ -1548,6 +1592,8 @@ export default function Preview({
     const onMouseDown = (e: MouseEvent) => {
       if (e.button !== 1) return; // middle button only
       e.preventDefault();
+      // User is manually panning — disable auto-fit on panel resize.
+      isFitModeRef.current = false;
       midPanDragRef.current = {
         startX: e.clientX,
         startY: e.clientY,
@@ -1892,11 +1938,13 @@ export default function Preview({
   // ── Zoom button handlers ──────────────────────────────────────────────────
 
   const handleZoomIn = useCallback(() => {
+    isFitModeRef.current = false;
     const newZoom = clamp(viewZoomRef.current + ZOOM_STEP, MIN_VIEW_ZOOM, MAX_VIEW_ZOOM);
     setZoom(newZoom);
   }, [setZoom]);
 
   const handleZoomOut = useCallback(() => {
+    isFitModeRef.current = false;
     const newZoom = clamp(viewZoomRef.current - ZOOM_STEP, MIN_VIEW_ZOOM, MAX_VIEW_ZOOM);
     setZoom(newZoom);
   }, [setZoom]);


### PR DESCRIPTION
## Summary

The fix is committed. Here's a summary of what was done:

**Root cause:** When the user resized the preview panel, the canvas had fixed CSS dimensions (1280×720) but `viewZoom` didn't update. This caused the canvas to overflow the smaller container — since the flex layout centers the canvas, elements near the edges were clipped off-screen, making them appear to shift position.

**Fix:** Added a `ResizeObserver` on the preview container that automatically recalculates and applies the fit zoom when the panel is resized. A `isFitModeRef` flag distinguishes "fit mode" (auto-fits on resize — default after project load or clicking the fit button) from "manual mode" (user's custom zoom preserved — activated by scroll wheel, zoom buttons, or middle-mouse pan). Only canvas `viewZoom` is updated; internal resolution and CSS dimensions remain unchanged.

**Tests:** Updated `PreviewCanvasResize.test.tsx` with a functional `ResizeObserver` stub and 3 new tests verifying that panel resize updates zoom but never changes canvas dimensions.

## Commits

- fix: auto-fit preview zoom on panel resize to prevent element position shift