### PR TITLE
Fixni build a oprav vsechny bugy, aby to prochzelo bez chyb. Ted mi totiz neprochazi pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1921,6 +1921,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -2103,6 +2110,34 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/chai/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2244,6 +2279,56 @@
         "@vitest/spy": "1.6.1",
         "@vitest/utils": "1.6.1",
         "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -3367,6 +3452,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3403,7 +3495,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3505,6 +3596,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-content-type-parse": {
@@ -4912,6 +5013,17 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
       "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
@@ -6428,6 +6540,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6480,6 +6602,16 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
       "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6811,7 +6943,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7400,7 +7531,6 @@
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -7419,7 +7549,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8251,7 +8380,187 @@
       "name": "@video-editor/shared",
       "version": "1.0.0",
       "devDependencies": {
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.0.18"
+      }
+    },
+    "packages/shared/node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/shared/node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/shared/node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/shared/node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/shared/node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/shared/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/shared/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/shared/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/shared/node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     }
   }

--- a/packages/elements/src/effects/index.ts
+++ b/packages/elements/src/effects/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Effect Registry — @video-editor/elements
+ *
+ * EFFECT_REGISTRY is the ordered list of all video clip effects.
+ * Applied within VideoClip rendering in this exact order (both preview and export).
+ *
+ * Current order and rationale:
+ *   1. BeatZoom   — Phase 1 (modifies transform BEFORE bounds computed)
+ *   2. Cutout     — Phase 2 first: draws background, returns masked canvas
+ *   3. Cartoon    — Phase 2 second: stylizes the (possibly masked) source
+ *   4. ColorGrade — Phase 2 last: color correction on top of everything
+ *
+ * To change the order or add a new effect, modify this array.
+ */
+
+import type { EffectDefinition } from '../types';
+import { BeatZoomEffect } from './BeatZoom';
+import { CutoutEffect } from './Cutout';
+import { CartoonEffect } from './Cartoon';
+import { ColorGradeEffect } from './ColorGrade';
+
+export { BeatZoomEffect, computeBeatZoomScale } from './BeatZoom';
+export { CartoonEffect, processCartoonFrame } from './Cartoon';
+export { ColorGradeEffect, processColorGradeFrame, buildColorGradeCssFilter } from './ColorGrade';
+export { CutoutEffect, getOrCreateMaskVideoEl, maskVideoCache, applyCutoutPreview } from './Cutout';
+
+export const EFFECT_REGISTRY: readonly EffectDefinition[] = [
+  BeatZoomEffect,
+  CutoutEffect,
+  CartoonEffect,
+  ColorGradeEffect,
+];

--- a/packages/elements/src/index.ts
+++ b/packages/elements/src/index.ts
@@ -114,34 +114,17 @@ export {
 
 // ─── Effect exports ───────────────────────────────────────────────────────────
 
-export { BeatZoomEffect, computeBeatZoomScale } from './effects/BeatZoom';
-export { CartoonEffect, processCartoonFrame } from './effects/Cartoon';
-export { ColorGradeEffect, processColorGradeFrame, buildColorGradeCssFilter } from './effects/ColorGrade';
-export { CutoutEffect, getOrCreateMaskVideoEl, maskVideoCache, applyCutoutPreview } from './effects/Cutout';
-
-// ─── EFFECT_REGISTRY ──────────────────────────────────────────────────────────
-
-import type { EffectDefinition } from './types';
-import { BeatZoomEffect } from './effects/BeatZoom';
-import { CutoutEffect } from './effects/Cutout';
-import { CartoonEffect } from './effects/Cartoon';
-import { ColorGradeEffect } from './effects/ColorGrade';
-
-/**
- * Ordered registry of all video clip effects.
- *
- * Applied within VideoClip rendering in this exact order (both preview and export).
- * To change the order or add a new effect, modify this array.
- *
- * Current order and rationale:
- *   1. BeatZoom   — Phase 1 (modifies transform BEFORE bounds computed)
- *   2. Cutout     — Phase 2 first: draws background, returns masked canvas
- *   3. Cartoon    — Phase 2 second: stylizes the (possibly masked) source
- *   4. ColorGrade — Phase 2 last: color correction on top of everything
- */
-export const EFFECT_REGISTRY: readonly EffectDefinition[] = [
+export {
   BeatZoomEffect,
-  CutoutEffect,
+  computeBeatZoomScale,
   CartoonEffect,
+  processCartoonFrame,
   ColorGradeEffect,
-];
+  processColorGradeFrame,
+  buildColorGradeCssFilter,
+  CutoutEffect,
+  getOrCreateMaskVideoEl,
+  maskVideoCache,
+  applyCutoutPreview,
+  EFFECT_REGISTRY,
+} from './effects/index';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,9 +5,12 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/shared/src/__tests__/elementUtils.test.ts
+++ b/packages/shared/src/__tests__/elementUtils.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Unit tests for elementUtils.ts
+ *
+ * Tests getActiveEffectConfig, getOverlappingEffectConfig, and filterBeatsByDivision.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getActiveEffectConfig,
+  getOverlappingEffectConfig,
+  filterBeatsByDivision,
+} from '../elementUtils';
+import type { Project, Track, Clip } from '../types';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeProject(tracks: Track[]): Project {
+  return {
+    id: 'proj1',
+    name: 'Test',
+    duration: 10,
+    aspectRatio: '9:16',
+    outputResolution: { w: 1080, h: 1920 },
+    tracks,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  };
+}
+
+function makeVideoTrack(id = 'video1'): Track {
+  return { id, type: 'video', name: 'Video', clips: [] };
+}
+
+function makeEffectTrack(
+  parentTrackId: string,
+  effectType: 'beatZoom' | 'cutout' | 'cartoon' | 'colorGrade',
+  clips: Clip[] = []
+): Track {
+  return {
+    id: `effect-${effectType}`,
+    type: 'effect',
+    name: effectType,
+    effectType,
+    parentTrackId,
+    clips,
+  };
+}
+
+function makeEffectClip(
+  timelineStart: number,
+  timelineEnd: number,
+  effectType: 'beatZoom' | 'cutout' | 'cartoon' | 'colorGrade'
+): Clip {
+  return {
+    id: `effect-clip-${timelineStart}`,
+    assetId: 'asset1',
+    trackId: 'effect-track',
+    timelineStart,
+    timelineEnd,
+    sourceStart: 0,
+    sourceEnd: timelineEnd - timelineStart,
+    effectConfig: { effectType, enabled: true },
+  };
+}
+
+function makeVideoClip(timelineStart: number, timelineEnd: number): Clip {
+  return {
+    id: 'video-clip',
+    assetId: 'asset1',
+    trackId: 'video1',
+    timelineStart,
+    timelineEnd,
+    sourceStart: 0,
+    sourceEnd: timelineEnd - timelineStart,
+  };
+}
+
+// ─── getActiveEffectConfig ─────────────────────────────────────────────────────
+
+describe('getActiveEffectConfig', () => {
+  it('returns null when no effect track exists for the video track', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const project = makeProject([videoTrack]);
+    const result = getActiveEffectConfig(project, videoTrack, 'beatZoom', 2.0);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when effect track exists but no clip is active at currentTime', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const effectClip = makeEffectClip(5, 8, 'beatZoom');
+    const effectTrack = makeEffectTrack('video1', 'beatZoom', [effectClip]);
+    const project = makeProject([videoTrack, effectTrack]);
+
+    // Before clip start
+    expect(getActiveEffectConfig(project, videoTrack, 'beatZoom', 2.0)).toBeNull();
+    // After clip end
+    expect(getActiveEffectConfig(project, videoTrack, 'beatZoom', 9.0)).toBeNull();
+  });
+
+  it('returns effectConfig when currentTime is within a clip', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const effectClip = makeEffectClip(2, 6, 'beatZoom');
+    const effectTrack = makeEffectTrack('video1', 'beatZoom', [effectClip]);
+    const project = makeProject([videoTrack, effectTrack]);
+
+    const result = getActiveEffectConfig(project, videoTrack, 'beatZoom', 4.0);
+    expect(result).not.toBeNull();
+    expect(result?.effectType).toBe('beatZoom');
+    expect(result?.enabled).toBe(true);
+  });
+
+  it('returns effectConfig when currentTime equals clip start (inclusive)', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const effectClip = makeEffectClip(3, 7, 'cartoon');
+    const effectTrack = makeEffectTrack('video1', 'cartoon', [effectClip]);
+    const project = makeProject([videoTrack, effectTrack]);
+
+    const result = getActiveEffectConfig(project, videoTrack, 'cartoon', 3.0);
+    expect(result).not.toBeNull();
+    expect(result?.effectType).toBe('cartoon');
+  });
+
+  it('returns null when currentTime equals clip end (exclusive)', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const effectClip = makeEffectClip(3, 7, 'cartoon');
+    const effectTrack = makeEffectTrack('video1', 'cartoon', [effectClip]);
+    const project = makeProject([videoTrack, effectTrack]);
+
+    const result = getActiveEffectConfig(project, videoTrack, 'cartoon', 7.0);
+    expect(result).toBeNull();
+  });
+
+  it('does not match an effect track linked to a different video track', () => {
+    const videoTrack1 = makeVideoTrack('video1');
+    const videoTrack2 = makeVideoTrack('video2');
+    const effectClip = makeEffectClip(0, 10, 'cutout');
+    // Effect track is linked to video2, not video1
+    const effectTrack = makeEffectTrack('video2', 'cutout', [effectClip]);
+    const project = makeProject([videoTrack1, videoTrack2, effectTrack]);
+
+    expect(getActiveEffectConfig(project, videoTrack1, 'cutout', 5.0)).toBeNull();
+    expect(getActiveEffectConfig(project, videoTrack2, 'cutout', 5.0)).not.toBeNull();
+  });
+
+  it('does not match an effect track with a different effectType', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const effectClip = makeEffectClip(0, 10, 'cartoon');
+    const effectTrack = makeEffectTrack('video1', 'cartoon', [effectClip]);
+    const project = makeProject([videoTrack, effectTrack]);
+
+    // Looking for beatZoom, but track is cartoon
+    expect(getActiveEffectConfig(project, videoTrack, 'beatZoom', 5.0)).toBeNull();
+    // Correct effectType works
+    expect(getActiveEffectConfig(project, videoTrack, 'cartoon', 5.0)).not.toBeNull();
+  });
+
+  it('returns null for clip with no effectConfig', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const clipWithoutConfig: Clip = {
+      id: 'no-config-clip',
+      assetId: 'asset1',
+      trackId: 'effect-beatZoom',
+      timelineStart: 0,
+      timelineEnd: 10,
+      sourceStart: 0,
+      sourceEnd: 10,
+      // no effectConfig
+    };
+    const effectTrack = makeEffectTrack('video1', 'beatZoom', [clipWithoutConfig]);
+    const project = makeProject([videoTrack, effectTrack]);
+
+    expect(getActiveEffectConfig(project, videoTrack, 'beatZoom', 5.0)).toBeNull();
+  });
+});
+
+// ─── getOverlappingEffectConfig ────────────────────────────────────────────────
+
+describe('getOverlappingEffectConfig', () => {
+  it('returns null when no effect track exists', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const videoClip = makeVideoClip(0, 5);
+    const project = makeProject([videoTrack]);
+
+    expect(getOverlappingEffectConfig(project, videoTrack, 'beatZoom', videoClip)).toBeNull();
+  });
+
+  it('returns effectConfig when effect clip overlaps the video clip', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const videoClip = makeVideoClip(2, 6);
+    const effectClip = makeEffectClip(3, 8, 'beatZoom');
+    const effectTrack = makeEffectTrack('video1', 'beatZoom', [effectClip]);
+    const project = makeProject([videoTrack, effectTrack]);
+
+    const result = getOverlappingEffectConfig(project, videoTrack, 'beatZoom', videoClip);
+    expect(result).not.toBeNull();
+    expect(result?.effectType).toBe('beatZoom');
+  });
+
+  it('returns null when effect clip ends exactly at video clip start (no overlap)', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const videoClip = makeVideoClip(5, 8);
+    const effectClip = makeEffectClip(0, 5, 'beatZoom'); // ends at 5, clip starts at 5
+    const effectTrack = makeEffectTrack('video1', 'beatZoom', [effectClip]);
+    const project = makeProject([videoTrack, effectTrack]);
+
+    expect(getOverlappingEffectConfig(project, videoTrack, 'beatZoom', videoClip)).toBeNull();
+  });
+
+  it('returns null when effect clip starts exactly at video clip end (no overlap)', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const videoClip = makeVideoClip(0, 5);
+    const effectClip = makeEffectClip(5, 8, 'beatZoom'); // starts at 5, clip ends at 5
+    const effectTrack = makeEffectTrack('video1', 'beatZoom', [effectClip]);
+    const project = makeProject([videoTrack, effectTrack]);
+
+    expect(getOverlappingEffectConfig(project, videoTrack, 'beatZoom', videoClip)).toBeNull();
+  });
+
+  it('returns effectConfig when effect clip fully contains the video clip', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const videoClip = makeVideoClip(3, 6);
+    const effectClip = makeEffectClip(0, 10, 'cutout');
+    const effectTrack = makeEffectTrack('video1', 'cutout', [effectClip]);
+    const project = makeProject([videoTrack, effectTrack]);
+
+    expect(getOverlappingEffectConfig(project, videoTrack, 'cutout', videoClip)).not.toBeNull();
+  });
+
+  it('returns effectConfig when video clip fully contains the effect clip', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const videoClip = makeVideoClip(0, 10);
+    const effectClip = makeEffectClip(3, 6, 'cartoon');
+    const effectTrack = makeEffectTrack('video1', 'cartoon', [effectClip]);
+    const project = makeProject([videoTrack, effectTrack]);
+
+    expect(getOverlappingEffectConfig(project, videoTrack, 'cartoon', videoClip)).not.toBeNull();
+  });
+
+  it('returns first overlapping clip when multiple effect clips are present', () => {
+    const videoTrack = makeVideoTrack('video1');
+    const videoClip = makeVideoClip(4, 7);
+    const effectClip1 = makeEffectClip(0, 5, 'beatZoom');
+    const effectClip2: Clip = {
+      ...makeEffectClip(5, 10, 'beatZoom'),
+      id: 'effect-clip-5',
+      effectConfig: { effectType: 'beatZoom', enabled: false, intensity: 0.2 },
+    };
+    const effectTrack = makeEffectTrack('video1', 'beatZoom', [effectClip1, effectClip2]);
+    const project = makeProject([videoTrack, effectTrack]);
+
+    // videoClip [4,7) overlaps effectClip1 [0,5) and effectClip2 [5,10)
+    const result = getOverlappingEffectConfig(project, videoTrack, 'beatZoom', videoClip);
+    // Returns the first matching one
+    expect(result?.effectType).toBe('beatZoom');
+    expect(result?.enabled).toBe(true); // effectClip1
+  });
+});
+
+// ─── filterBeatsByDivision ─────────────────────────────────────────────────────
+
+describe('filterBeatsByDivision', () => {
+  const beats = [0, 1, 2, 3, 4, 5];
+
+  it('returns all beats when beatDivision is 1', () => {
+    expect(filterBeatsByDivision(beats, 1)).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  it('returns every 2nd beat when beatDivision is 2', () => {
+    expect(filterBeatsByDivision(beats, 2)).toEqual([0, 2, 4]);
+  });
+
+  it('returns every 4th beat when beatDivision is 4', () => {
+    expect(filterBeatsByDivision(beats, 4)).toEqual([0, 4]);
+  });
+
+  it('interpolates sub-beats when beatDivision is 0.5 (twice per beat)', () => {
+    const result = filterBeatsByDivision([0, 1, 2], 0.5);
+    // Expect: 0, 0.5, 1, 1.5, 2
+    expect(result).toHaveLength(5);
+    expect(result[0]).toBe(0);
+    expect(result[1]).toBeCloseTo(0.5);
+    expect(result[2]).toBe(1);
+    expect(result[3]).toBeCloseTo(1.5);
+    expect(result[4]).toBe(2);
+  });
+
+  it('interpolates sub-beats when beatDivision is 0.25 (4x per beat)', () => {
+    const result = filterBeatsByDivision([0, 1], 0.25);
+    // Expect: 0, 0.25, 0.5, 0.75, 1
+    expect(result).toHaveLength(5);
+    expect(result[0]).toBe(0);
+    expect(result[1]).toBeCloseTo(0.25);
+    expect(result[2]).toBeCloseTo(0.5);
+    expect(result[3]).toBeCloseTo(0.75);
+    expect(result[4]).toBe(1);
+  });
+
+  it('returns input beats unchanged when beatDivision is 0 or negative', () => {
+    expect(filterBeatsByDivision(beats, 0)).toEqual(beats);
+    expect(filterBeatsByDivision(beats, -1)).toEqual(beats);
+  });
+
+  it('handles empty beats array', () => {
+    expect(filterBeatsByDivision([], 1)).toEqual([]);
+    expect(filterBeatsByDivision([], 0.5)).toEqual([]);
+  });
+
+  it('handles single beat array', () => {
+    expect(filterBeatsByDivision([5], 1)).toEqual([5]);
+    expect(filterBeatsByDivision([5], 2)).toEqual([5]);
+    // Single beat → no interpolation possible after it
+    expect(filterBeatsByDivision([5], 0.5)).toEqual([5]);
+  });
+
+  it('rounds non-integer beat division to nearest step', () => {
+    // beatDivision=2.7 should round to step=3
+    const result = filterBeatsByDivision([0, 1, 2, 3, 4, 5], 2.7);
+    expect(result).toEqual([0, 3]);
+  });
+});

--- a/packages/shared/src/elementUtils.ts
+++ b/packages/shared/src/elementUtils.ts
@@ -1,0 +1,123 @@
+/**
+ * Element utility functions for shared use across packages.
+ *
+ * These helpers look up effect configuration from the project data model.
+ * They are used by effect implementations in @video-editor/elements to find
+ * the active EffectClipConfig for a given video track and effect type.
+ */
+
+import type { Project, Track, Clip, EffectClipConfig, EffectType } from './types';
+
+// ─── Effect track lookup ──────────────────────────────────────────────────────
+
+/**
+ * Finds the effect track for the given video track and effect type.
+ * Returns the first effect track in project.tracks where:
+ *   - track.type === 'effect'
+ *   - track.effectType === effectType
+ *   - track.parentTrackId === videoTrack.id
+ */
+function findEffectTrack(
+  project: Project,
+  videoTrack: Track,
+  effectType: EffectType
+): Track | undefined {
+  return project.tracks.find(
+    (t) =>
+      t.type === 'effect' &&
+      t.effectType === effectType &&
+      t.parentTrackId === videoTrack.id
+  );
+}
+
+// ─── Active effect config (preview side) ─────────────────────────────────────
+
+/**
+ * Returns the EffectClipConfig for the effect of `effectType` that is active
+ * at `currentTime` on the effect track linked to `videoTrack`.
+ *
+ * "Active" means currentTime falls within [clip.timelineStart, clip.timelineEnd).
+ *
+ * Returns null if:
+ *   - No effect track of the given type is linked to videoTrack
+ *   - No clip is active at currentTime
+ *   - The active clip has no effectConfig
+ */
+export function getActiveEffectConfig(
+  project: Project,
+  videoTrack: Track,
+  effectType: EffectType,
+  currentTime: number
+): EffectClipConfig | null {
+  const effectTrack = findEffectTrack(project, videoTrack, effectType);
+  if (!effectTrack) return null;
+
+  const activeClip = effectTrack.clips.find(
+    (c) => currentTime >= c.timelineStart && currentTime < c.timelineEnd
+  );
+  return activeClip?.effectConfig ?? null;
+}
+
+// ─── Overlapping effect config (export side) ──────────────────────────────────
+
+/**
+ * Returns the EffectClipConfig for the effect of `effectType` whose clip
+ * overlaps with `videoClip` on the effect track linked to `videoTrack`.
+ *
+ * "Overlapping" means the effect clip's time range intersects the video clip's
+ * time range: effectClip.timelineStart < videoClip.timelineEnd AND
+ *              effectClip.timelineEnd   > videoClip.timelineStart
+ *
+ * Returns null if:
+ *   - No effect track of the given type is linked to videoTrack
+ *   - No effect clip overlaps with videoClip
+ *   - The overlapping clip has no effectConfig
+ */
+export function getOverlappingEffectConfig(
+  project: Project,
+  videoTrack: Track,
+  effectType: EffectType,
+  videoClip: Clip
+): EffectClipConfig | null {
+  const effectTrack = findEffectTrack(project, videoTrack, effectType);
+  if (!effectTrack) return null;
+
+  const overlappingClip = effectTrack.clips.find(
+    (c) =>
+      c.timelineStart < videoClip.timelineEnd &&
+      c.timelineEnd > videoClip.timelineStart
+  );
+  return overlappingClip?.effectConfig ?? null;
+}
+
+// ─── Beat division filter ──────────────────────────────────────────────────────
+
+/**
+ * Filters a beat array based on the beatDivision parameter.
+ *
+ * beatDivision controls how many beats trigger an effect:
+ *   >= 1  → use every Nth beat (1=every beat, 2=every 2nd, 4=every 4th, …)
+ *   < 1   → interpolate sub-beat triggers (0.5=twice per beat, 0.25=4x per beat)
+ */
+export function filterBeatsByDivision(beats: number[], beatDivision: number): number[] {
+  if (beatDivision <= 0) return beats;
+
+  if (beatDivision >= 1) {
+    const step = Math.round(beatDivision);
+    return beats.filter((_, i) => i % step === 0);
+  }
+
+  // Sub-beat: interpolate evenly between consecutive beats
+  const subdivisions = Math.round(1 / beatDivision);
+  const result: number[] = [];
+  for (let i = 0; i < beats.length; i++) {
+    result.push(beats[i]);
+    if (i < beats.length - 1) {
+      const interval = beats[i + 1] - beats[i];
+      for (let j = 1; j < subdivisions; j++) {
+        result.push(beats[i] + (j / subdivisions) * interval);
+      }
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

Pipeline is now fully passing. Here's what was fixed:

1. **Created `packages/shared/src/elementUtils.ts`** — this file was referenced by `packages/shared/src/index.ts` via `export * from './elementUtils'` but didn't exist. It now contains `getActiveEffectConfig`, `getOverlappingEffectConfig`, and `filterBeatsByDivision`, which all four effects (BeatZoom, Cutout, Cartoon, ColorGrade) import from `@video-editor/shared`.

2. **Created `packages/elements/src/effects/index.ts`** — the test file `effectRegistry.test.ts` imported `EFFECT_REGISTRY` from `'../effects/index'` but that file didn't exist. The `EFFECT_REGISTRY` was moved here as its canonical home and the main `index.ts` was updated to re-export from it.

3. **Added 24 unit tests** for `elementUtils.ts` in `packages/shared/src/__tests__/elementUtils.test.ts`, covering all functions and edge cases. All 315 tests across all packages now pass and the complete build (shared → api → web) succeeds cleanly.

## Commits

- fix: restore missing elementUtils and effects/index to fix build pipeline
- fix: auto-fit preview zoom on panel resize to prevent element position shift