### PR TITLE
Fix build" out: npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized s

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -40,8 +40,8 @@ COPY apps/api/package.json ./apps/api/
 # Create empty web package.json so npm workspace glob doesn't fail
 COPY apps/web/package.json ./apps/web/
 
-# Install Node dependencies (root-level installs all workspaces)
-RUN npm ci --ignore-scripts
+# Install Node dependencies and clean npm cache in same layer
+RUN npm ci --ignore-scripts && npm cache clean --force
 
 # Build shared package
 COPY packages/shared/tsconfig.json ./packages/shared/
@@ -60,28 +60,18 @@ COPY apps/api/src ./apps/api/src
 # Copy Python scripts
 COPY scripts ./scripts
 
-# Install Python dependencies (lightweight core ones, skip Whisper/torch by default)
+# Install all Python dependencies in a single layer to minimize VFS overhead
 COPY requirements.txt ./
-RUN pip3 install --no-cache-dir --break-system-packages --only-binary=:all: librosa soundfile numpy \
-    || pip3 install --no-cache-dir --only-binary=:all: librosa soundfile numpy
-
-# Install cutout dependencies (rembg for AI background removal)
-RUN pip3 install --no-cache-dir --break-system-packages rembg onnxruntime pillow \
-    || pip3 install --no-cache-dir rembg onnxruntime pillow
-
-# Pre-download the rembg segmentation model so the first cutout job doesn't
-# need network access and avoids a silent hang while downloading ~170 MB.
-# Falls back gracefully if the build host has no internet access.
-RUN python3 -c "from rembg import new_session; new_session('u2net_human_seg'); print('rembg model cached')" \
-    || echo "WARNING: rembg model pre-download failed – it will be downloaded on first use"
-
-# Install head stabilization dependencies (opencv for face detection)
-RUN pip3 install --no-cache-dir --break-system-packages --only-binary=:all: opencv-python-headless \
-    || pip3 install --no-cache-dir --only-binary=:all: opencv-python-headless
-
-# Whisper for lyrics auto-transcription (faster-whisper uses CTranslate2, much smaller than openai-whisper+torch)
-RUN pip3 install --no-cache-dir --break-system-packages faster-whisper \
-    || pip3 install --no-cache-dir faster-whisper
+RUN (pip3 install --no-cache-dir --break-system-packages --only-binary=:all: librosa soundfile numpy \
+    || pip3 install --no-cache-dir --only-binary=:all: librosa soundfile numpy) \
+    && (pip3 install --no-cache-dir --break-system-packages rembg onnxruntime pillow \
+    || pip3 install --no-cache-dir rembg onnxruntime pillow) \
+    && (python3 -c "from rembg import new_session; new_session('u2net_human_seg'); print('rembg model cached')" \
+    || echo "WARNING: rembg model pre-download failed – it will be downloaded on first use") \
+    && (pip3 install --no-cache-dir --break-system-packages --only-binary=:all: opencv-python-headless \
+    || pip3 install --no-cache-dir --only-binary=:all: opencv-python-headless) \
+    && (pip3 install --no-cache-dir --break-system-packages faster-whisper \
+    || pip3 install --no-cache-dir faster-whisper)
 
 # Build API
 RUN npm run build -w apps/api

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -12,8 +12,8 @@ COPY apps/web/package.json ./apps/web/
 # Create empty api package.json so npm workspace glob doesn't fail
 COPY apps/api/package.json ./apps/api/
 
-# Install all deps
-RUN npm ci --ignore-scripts
+# Install all deps and clean cache in same layer to save space (VFS driver)
+RUN npm ci --ignore-scripts && npm cache clean --force
 
 # Copy shared + elements source, build them, then copy web source and build it
 COPY packages/shared ./packages/shared
@@ -29,6 +29,9 @@ RUN npm run build -w packages/shared \
     && npm run build -w packages/elements \
     && npm run build -w apps/web
 
+# Prune dev dependencies so we can copy clean node_modules to production
+RUN npm prune --omit=dev && npm cache clean --force
+
 # --- Production stage ---
 FROM node:20-slim
 
@@ -43,10 +46,14 @@ COPY --from=builder /app/packages/elements/dist ./packages/elements/dist
 COPY --from=builder /app/apps/web/package.json ./apps/web/
 COPY --from=builder /app/apps/web/.next ./apps/web/.next
 COPY --from=builder /app/apps/web/next.config.mjs ./apps/web/
-COPY --from=builder /app/apps/api/package.json ./apps/api/
 
-# Install production deps only
-RUN npm ci --omit=dev --ignore-scripts
+# Stub api package.json so npm workspace resolution works
+RUN mkdir -p apps/api && echo '{"name":"@video-editor/api","version":"1.0.0","private":true}' > apps/api/package.json
+
+# Copy pre-pruned node_modules from builder instead of re-running npm ci
+# This avoids a second install pass and saves significant disk space
+# All deps are hoisted to root node_modules in npm workspaces
+COPY --from=builder /app/node_modules ./node_modules
 
 ENV NODE_ENV=production
 ENV PORT=3000


### PR DESCRIPTION
## Task

Fix build" out: npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
out: npm warn tar TAR_ENTRY_ERROR ENOSPC: no space left on device, write
out: npm warn tar TAR_ENTRY_ERROR ENOSPC: no space left on device, write
out: npm notice
out: npm notice New major version of npm available! 10.8.2 -> 11.11.1
out: npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.11.1
out: npm notice To update run: npm install -g npm@11.11.1
out: npm notice
out: npm error A complete log of this run can be found in: /***/.npm/_logs/2026-03-12T11_07_04_445Z-debug-0.log
err: The command '/bin/sh -c npm ci --omit=dev --ignore-scripts' returned a non-zero code: 1
out: