### PR TITLE
Stahovani ai style efekt modelu uz funguje... ale process toho efektu stale ne: AI Style failed

### DIFF
--- a/scripts/ai_style.py
+++ b/scripts/ai_style.py
@@ -463,8 +463,9 @@ def stylize_frame_neural(frame: np.ndarray, session,
     - brush_size=0 → process at higher resolution (finer cartoon details)
     - brush_size=1 → process at lower resolution (broader, more stylized)
 
-    AnimeGANv2 input:  [1, 3, H, W] float32, normalized to [-1, 1]
-    AnimeGANv2 output: [1, 3, H, W] float32, in [-1, 1] range
+    The model format (NHWC vs NCHW) is auto-detected from the ONNX input shape.
+    AnimeGANv2 input:  float32, normalized to [-1, 1]
+    AnimeGANv2 output: float32, in [-1, 1] range
     """
     h, w = frame.shape[:2]
 
@@ -486,17 +487,30 @@ def stylize_frame_neural(frame: np.ndarray, session,
     # Convert BGR→RGB, normalize to [-1, 1] (AnimeGANv2 input range)
     rgb = cv2.cvtColor(proc_frame, cv2.COLOR_BGR2RGB).astype(np.float32)
     input_tensor = rgb / 127.5 - 1.0  # [0, 255] → [-1, 1]
-    input_tensor = np.transpose(input_tensor, (2, 0, 1))  # HWC → CHW
+
+    # Auto-detect model layout from ONNX input shape
+    input_meta = session.get_inputs()[0]
+    input_name = input_meta.name
+    input_shape = input_meta.shape  # e.g. [1, 3, H, W] or [1, H, W, 3]
+    # Determine if model expects NCHW (channel dim at index 1) or NHWC (channel dim at index 3)
+    is_nchw = (len(input_shape) == 4 and isinstance(input_shape[1], int) and input_shape[1] == 3)
+
+    if is_nchw:
+        input_tensor = np.transpose(input_tensor, (2, 0, 1))  # HWC → CHW
+    # else: keep HWC layout for NHWC models (e.g. TensorFlow-exported AnimeGANv2)
+
     input_tensor = np.expand_dims(input_tensor, axis=0)  # add batch dim
 
     # Run inference
-    input_name = session.get_inputs()[0].name
     output_name = session.get_outputs()[0].name
     result = session.run([output_name], {input_name: input_tensor})[0]
 
-    # Convert output: [1, 3, H, W] → [H, W, 3] BGR uint8
+    # Convert output back to HWC BGR uint8
     output = result[0]  # remove batch dim
-    output = np.transpose(output, (1, 2, 0))  # CHW → HWC
+    if is_nchw:
+        output = np.transpose(output, (1, 2, 0))  # CHW → HWC
+    # else: output is already HWC for NHWC models
+
     # Denormalize from [-1, 1] → [0, 255]
     output = (output + 1.0) * 127.5
     output = np.clip(output, 0, 255).astype(np.uint8)

--- a/scripts/test_ai_style.py
+++ b/scripts/test_ai_style.py
@@ -8,6 +8,8 @@ import http.server
 import threading
 import numpy as np
 
+from unittest.mock import MagicMock
+
 from ai_style import (
     STYLE_MODELS,
     MODEL_BASE_URL,
@@ -22,6 +24,7 @@ from ai_style import (
     download_model,
     get_model_status,
     resolve_model,
+    stylize_frame_neural,
     _get_models_dir,
 )
 
@@ -531,6 +534,70 @@ class TestStyleModelConfig(unittest.TestCase):
         """Each model should have a sha256 field (can be None)."""
         for name, info in STYLE_MODELS.items():
             self.assertIn('sha256', info, f"Model '{name}' missing 'sha256'")
+
+
+class TestStylizeFrameNeural(unittest.TestCase):
+    """Tests for stylize_frame_neural ONNX input layout auto-detection."""
+
+    def _make_mock_session(self, input_shape, output_is_nchw=None):
+        """Create a mock ONNX session with given input shape.
+
+        The mock session.run returns a transformed tensor that can be verified.
+        If output_is_nchw is None, it matches the input layout.
+        """
+        session = MagicMock()
+
+        input_meta = MagicMock()
+        input_meta.name = 'input:0'
+        input_meta.shape = input_shape
+        session.get_inputs.return_value = [input_meta]
+
+        output_meta = MagicMock()
+        output_meta.name = 'output:0'
+        session.get_outputs.return_value = [output_meta]
+
+        # Detect layout from input shape
+        is_nchw = (len(input_shape) == 4 and isinstance(input_shape[1], int)
+                   and input_shape[1] == 3)
+
+        def mock_run(output_names, input_feed, run_options=None):
+            tensor = list(input_feed.values())[0]
+            # Verify tensor shape matches expected layout
+            if is_nchw:
+                assert tensor.shape[1] == 3, (
+                    f"NCHW model got channel dim {tensor.shape[1]}, expected 3")
+            else:
+                assert tensor.shape[3] == 3, (
+                    f"NHWC model got channel dim {tensor.shape[3]}, expected 3")
+            # Return same tensor as output (identity stylization for testing)
+            return [tensor]
+
+        session.run = mock_run
+        return session
+
+    def test_nhwc_model_input_not_transposed(self):
+        """NHWC model (TF-exported) should receive [1, H, W, 3] tensor."""
+        frame = np.random.randint(0, 255, (64, 80, 3), dtype=np.uint8)
+        session = self._make_mock_session([1, None, None, 3])
+        result = stylize_frame_neural(frame, session, brush_size=0.5)
+        self.assertEqual(result.shape, frame.shape)
+        self.assertEqual(result.dtype, np.uint8)
+
+    def test_nchw_model_input_transposed(self):
+        """NCHW model (PyTorch-exported) should receive [1, 3, H, W] tensor."""
+        frame = np.random.randint(0, 255, (64, 80, 3), dtype=np.uint8)
+        session = self._make_mock_session([1, 3, None, None])
+        result = stylize_frame_neural(frame, session, brush_size=0.5)
+        self.assertEqual(result.shape, frame.shape)
+        self.assertEqual(result.dtype, np.uint8)
+
+    def test_output_values_in_valid_range(self):
+        """Output pixels should be in [0, 255] uint8 range."""
+        frame = np.random.randint(0, 255, (64, 80, 3), dtype=np.uint8)
+        session = self._make_mock_session([1, None, None, 3])
+        result = stylize_frame_neural(frame, session, brush_size=0.5)
+        self.assertTrue(np.all(result >= 0))
+        self.assertTrue(np.all(result <= 255))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Task

Stahovani ai style efekt modelu uz funguje... ale process toho efektu stale ne: AI Style failed
23:17:27
×
Process failed (exit code 1): return self._sess.run(output_names, input_feed, run_options) | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument: [ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Got invalid dimensions for input: generator_input:0 for the following indices | index: 3 Got: 216 Expected: 3 | Please fix either the inputs/outputs or the model.
Log details (20 lines)
[ai_style] Processing 1748 frames...
[ai_style] Found 2 scene(s) / 1 cut(s).
[ai_style] Keyframe interval: every 5 frames
[ai_style] Cartoonizing keyframes with AnimeGANv2...
Traceback (most recent call last):
  File "/app/scripts/ai_style.py", line 820, in <module>
    process_ai_style(input_path, output_path, strength, brush, vibrance, preset)
  File "/app/scripts/ai_style.py", line 676, in process_ai_style
    styled = stylize_frame_neural(frame, session, brush_size)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/scripts/ai_style.py", line 495, in stylize_frame_neural
    result = session.run([output_name], {input_name: input_tensor})[0]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/onnxruntime/capi/onnxruntime_inference_collection.py", line 296, in run
    return self._sess.run(output_names, input_feed, run_options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument: [ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Got invalid dimensions for input: generator_input:0 for the following indices
 index: 3 Got: 216 Expected: 3
 Please fix either the inputs/outputs or the model.
Process failed (exit code 1):     return self._sess.run(output_names, input_feed, run_options) |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument: [ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Got invalid dimensions for input: generator_input:0 for the following indices |  index: 3 Got: 216 Expected: 3 |  Please fix either the inputs/outputs or the model.... oprav... je treba aby slo pouzivat ty ai cartoon efekty