### PR TITLE
Process ai style mi stale nejak nefunguje: AI Style failed

### DIFF
--- a/scripts/ai_style.py
+++ b/scripts/ai_style.py
@@ -492,24 +492,34 @@ def stylize_frame_neural(frame: np.ndarray, session,
     input_meta = session.get_inputs()[0]
     input_name = input_meta.name
     input_shape = input_meta.shape  # e.g. [1, 3, H, W] or [1, H, W, 3]
-    # Determine if model expects NCHW (channel dim at index 1) or NHWC (channel dim at index 3)
-    is_nchw = (len(input_shape) == 4 and isinstance(input_shape[1], int) and input_shape[1] == 3)
-
-    if is_nchw:
-        input_tensor = np.transpose(input_tensor, (2, 0, 1))  # HWC → CHW
-    # else: keep HWC layout for NHWC models (e.g. TensorFlow-exported AnimeGANv2)
-
-    input_tensor = np.expand_dims(input_tensor, axis=0)  # add batch dim
-
-    # Run inference
     output_name = session.get_outputs()[0].name
-    result = session.run([output_name], {input_name: input_tensor})[0]
 
-    # Convert output back to HWC BGR uint8
-    output = result[0]  # remove batch dim
-    if is_nchw:
-        output = np.transpose(output, (1, 2, 0))  # CHW → HWC
-    # else: output is already HWC for NHWC models
+    # Determine if model expects NCHW (channel dim at index 1) or NHWC (channel dim at index 3)
+    # Check NHWC first: if index 3 is explicitly 3, it's channels-last (TF convention)
+    is_nhwc = (len(input_shape) == 4 and isinstance(input_shape[3], int) and input_shape[3] == 3)
+    is_nchw = (len(input_shape) == 4 and isinstance(input_shape[1], int) and input_shape[1] == 3 and not is_nhwc)
+    # TF-exported models use ':N' suffix in input names — override to NHWC
+    # (some TF→ONNX exports declare NCHW in metadata but graph ops remain NHWC)
+    if is_nchw and ':' in input_name:
+        is_nchw = False
+
+    def _run_inference(tensor_hwc, use_nchw):
+        """Prepare tensor, run inference, return HWC output."""
+        t = tensor_hwc
+        if use_nchw:
+            t = np.transpose(t, (2, 0, 1))  # HWC → CHW
+        t = np.expand_dims(t, axis=0)  # add batch dim
+        out = session.run([output_name], {input_name: t})[0]
+        out = out[0]  # remove batch dim
+        if use_nchw:
+            out = np.transpose(out, (1, 2, 0))  # CHW → HWC
+        return out
+
+    # Run inference with fallback: if detected layout fails, try the other
+    try:
+        output = _run_inference(input_tensor, is_nchw)
+    except Exception:
+        output = _run_inference(input_tensor, not is_nchw)
 
     # Denormalize from [-1, 1] → [0, 255]
     output = (output + 1.0) * 127.5

--- a/scripts/test_ai_style.py
+++ b/scripts/test_ai_style.py
@@ -539,16 +539,22 @@ class TestStyleModelConfig(unittest.TestCase):
 class TestStylizeFrameNeural(unittest.TestCase):
     """Tests for stylize_frame_neural ONNX input layout auto-detection."""
 
-    def _make_mock_session(self, input_shape, output_is_nchw=None):
+    def _make_mock_session(self, input_shape, input_name='input:0',
+                           actual_layout='auto'):
         """Create a mock ONNX session with given input shape.
 
-        The mock session.run returns a transformed tensor that can be verified.
-        If output_is_nchw is None, it matches the input layout.
+        Args:
+            input_shape: ONNX input shape metadata (e.g. [1, 3, None, None])
+            input_name: ONNX input tensor name
+            actual_layout: What the model actually accepts:
+                'nhwc' - validates channels at index 3
+                'nchw' - validates channels at index 1
+                'auto' - infer from input_shape (matches old behavior)
         """
         session = MagicMock()
 
         input_meta = MagicMock()
-        input_meta.name = 'input:0'
+        input_meta.name = input_name
         input_meta.shape = input_shape
         session.get_inputs.return_value = [input_meta]
 
@@ -556,20 +562,29 @@ class TestStylizeFrameNeural(unittest.TestCase):
         output_meta.name = 'output:0'
         session.get_outputs.return_value = [output_meta]
 
-        # Detect layout from input shape
-        is_nchw = (len(input_shape) == 4 and isinstance(input_shape[1], int)
-                   and input_shape[1] == 3)
+        if actual_layout == 'auto':
+            # Infer from shape: if index 3 is 3 → NHWC, elif index 1 is 3 → NCHW
+            if (len(input_shape) == 4 and isinstance(input_shape[3], int)
+                    and input_shape[3] == 3):
+                actual_layout = 'nhwc'
+            elif (len(input_shape) == 4 and isinstance(input_shape[1], int)
+                  and input_shape[1] == 3):
+                actual_layout = 'nchw'
+            else:
+                actual_layout = 'nhwc'
 
         def mock_run(output_names, input_feed, run_options=None):
             tensor = list(input_feed.values())[0]
-            # Verify tensor shape matches expected layout
-            if is_nchw:
-                assert tensor.shape[1] == 3, (
-                    f"NCHW model got channel dim {tensor.shape[1]}, expected 3")
+            if actual_layout == 'nchw':
+                if tensor.shape[1] != 3:
+                    raise RuntimeError(
+                        f"INVALID_ARGUMENT: index: 1 Got: {tensor.shape[1]} "
+                        f"Expected: 3")
             else:
-                assert tensor.shape[3] == 3, (
-                    f"NHWC model got channel dim {tensor.shape[3]}, expected 3")
-            # Return same tensor as output (identity stylization for testing)
+                if tensor.shape[3] != 3:
+                    raise RuntimeError(
+                        f"INVALID_ARGUMENT: index: 3 Got: {tensor.shape[3]} "
+                        f"Expected: 3")
             return [tensor]
 
         session.run = mock_run
@@ -586,7 +601,9 @@ class TestStylizeFrameNeural(unittest.TestCase):
     def test_nchw_model_input_transposed(self):
         """NCHW model (PyTorch-exported) should receive [1, 3, H, W] tensor."""
         frame = np.random.randint(0, 255, (64, 80, 3), dtype=np.uint8)
-        session = self._make_mock_session([1, 3, None, None])
+        # Use non-TF name so ':' override doesn't kick in
+        session = self._make_mock_session([1, 3, None, None],
+                                          input_name='input')
         result = stylize_frame_neural(frame, session, brush_size=0.5)
         self.assertEqual(result.shape, frame.shape)
         self.assertEqual(result.dtype, np.uint8)
@@ -598,6 +615,50 @@ class TestStylizeFrameNeural(unittest.TestCase):
         result = stylize_frame_neural(frame, session, brush_size=0.5)
         self.assertTrue(np.all(result >= 0))
         self.assertTrue(np.all(result <= 255))
+
+    def test_tf_naming_overrides_nchw_to_nhwc(self):
+        """TF-exported model with ':0' name but NCHW metadata should use NHWC.
+
+        This is the exact bug scenario: TF→ONNX export declares [1, 3, H, W]
+        in metadata, but internal graph ops expect NHWC. Input name has ':0'
+        suffix (TF convention). Without the fix, this produces:
+        INVALID_ARGUMENT: index: 3 Got: <width> Expected: 3
+        """
+        frame = np.random.randint(0, 255, (64, 216, 3), dtype=np.uint8)
+        # Shape metadata says NCHW, but model actually expects NHWC
+        session = self._make_mock_session(
+            [1, 3, 'height', 'width'],
+            input_name='generator_input:0',
+            actual_layout='nhwc'
+        )
+        result = stylize_frame_neural(frame, session, brush_size=0.5)
+        self.assertEqual(result.shape, frame.shape)
+        self.assertEqual(result.dtype, np.uint8)
+
+    def test_fallback_on_layout_mismatch(self):
+        """If detected layout fails at runtime, fallback to other layout."""
+        frame = np.random.randint(0, 255, (64, 80, 3), dtype=np.uint8)
+        # Shape metadata is all dynamic — no clear NCHW/NHWC signal
+        # Model actually expects NHWC; code defaults to NHWC, should work
+        session = self._make_mock_session(
+            [1, None, None, None],
+            input_name='input',
+            actual_layout='nhwc'
+        )
+        result = stylize_frame_neural(frame, session, brush_size=0.5)
+        self.assertEqual(result.shape, frame.shape)
+
+    def test_nhwc_explicit_wins_over_nchw_hint(self):
+        """When both dim 1 and dim 3 are 3, NHWC (dim 3) takes priority."""
+        frame = np.random.randint(0, 255, (64, 80, 3), dtype=np.uint8)
+        # Contrived shape [1, 3, X, 3] — NHWC should take priority
+        session = self._make_mock_session(
+            [1, 3, None, 3],
+            input_name='input',
+            actual_layout='nhwc'
+        )
+        result = stylize_frame_neural(frame, session, brush_size=0.5)
+        self.assertEqual(result.shape, frame.shape)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Task

Process ai style mi stale nejak nefunguje: AI Style failed
23:35:24
×
Process failed (exit code 1): ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument: | [ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Got invalid dimensions for input: generator_input:0 for the following indices | index: 3 Got: 216 Expected: 3 | Please fix either the inputs/outputs or the model.
Log details (20 lines)
[ai_style] Keyframe interval: every 5 frames
[ai_style] Cartoonizing keyframes with AnimeGANv2...
Traceback (most recent call last):
  File "/app/scripts/ai_style.py", line 820, in <module>
    process_ai_style(input_path, output_path, strength, brush, vibrance, preset)
  File "/app/scripts/ai_style.py", line 676, in process_ai_style
    styled = stylize_frame_neural(frame, session, brush_size)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/scripts/ai_style.py", line 495, in stylize_frame_neural
    result = session.run([output_name], {input_name: input_tensor})[0]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/onnxruntime/capi/onnxruntime_inference_collection.py", line 296, in run
    
return self._sess.run(output_names, input_feed, run_options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument: 
[ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Got invalid dimensions for input: generator_input:0 for the following indices
 index: 3 Got: 216 Expected: 3
 Please fix either the inputs/outputs or the model.
Process failed (exit code 1):            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument:  | [ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Got invalid dimensions for input: generator_input:0 for the following indices |  index: 3 Got: 216 Expected: 3 |  Please fix either the inputs/outputs or the model. ... oprav